### PR TITLE
Add an option to allow disabling ampersand escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (target, opts) => {
 		return Promise.reject(new Error('Expected a `target`'));
 	}
 
-	opts = Object.assign({wait: true}, opts);
+	opts = Object.assign({ wait: true, escapeAmpersands: true }, opts);
 
 	let cmd;
 	let appArgs = [];
@@ -33,7 +33,9 @@ module.exports = (target, opts) => {
 	} else if (process.platform === 'win32' || isWsl) {
 		cmd = 'cmd' + (isWsl ? '.exe' : '');
 		args.push('/c', 'start', '""', '/b');
-		target = target.replace(/&/g, '^&');
+		if (opts.escapeAmpersands) {
+			target = target.replace(/&/g, '^&');
+		}
 
 		if (opts.wait) {
 			args.push('/wait');

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,15 @@ Specify the app to open the `target` with, or an array with the app and app argu
 
 The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows.
 
+##### escapeAmpersands
+
+Type: `boolean`<br>
+Default: `true`
+
+Escapes ampersands for your target on Windows, this is helpful when launching URL's when
+using query parameters.  If you are launching files from the file system, you probably
+want to set this to `false`.
+
 
 ## Related
 


### PR DESCRIPTION
We've found when launching files with a "&" in their filename this escaping breaks the launch.  (Windows throws a could not find file error).  This PR just adds an option to allow disabling the escaping 👍 