### PR TITLE
Fix cannot open url contains `|` on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = (target, opts) => {
 	} else if (process.platform === 'win32' || isWsl) {
 		cmd = 'cmd' + (isWsl ? '.exe' : '');
 		args.push('/c', 'start', '""', '/b');
-		target = target.replace(/&/g, '^&');
+		target = target.replace(/&/g, '^&').replace(/[|]/g, '^|');
 
 		if (opts.wait) {
 			args.push('/wait');

--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ module.exports = (target, opts) => {
 	} else if (process.platform === 'win32' || isWsl) {
 		cmd = 'cmd' + (isWsl ? '.exe' : '');
 		args.push('/c', 'start', '""', '/b');
-		target = target.replace(/&/g, '^&').replace(/[|]/g, '^|');
+		if (target.indexOf(' ') === -1) {
+			target = target.replace(/([&\\<>^|])/g, '^$1');
+		}
 
 		if (opts.wait) {
 			args.push('/wait');


### PR DESCRIPTION
- If contains space, **DO NOT** escape;
- otherwise, **DO** escape.
- No matter target is URL, or file path.
- Escape Character: `&` `\` `<` `>` `^` `|`

Detail in [#74 (comment)](https://github.com/sindresorhus/opn/pull/74#issuecomment-403681779).