### PR TITLE
Use the system `xdg-open` on Linux when `open` is bundled/packaged

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const { promisify } = require('util');
+const {promisify} = require('util');
 const path = require('path');
 const childProcess = require('child_process');
 const isWsl = require('is-wsl');
@@ -9,7 +9,7 @@ const pExecFile = promisify(childProcess.execFile);
 // Convert a path from WSL format to Windows format:
 // `/mnt/c/Program Files/Example/MyApp.exe` → `C:\Program Files\Example\MyApp.exe``
 const wslToWindowsPath = async path => {
-	const { stdout } = await pExecFile('wslpath', ['-w', path]);
+	const {stdout} = await pExecFile('wslpath', ['-w', path]);
 	return stdout.trim();
 };
 
@@ -73,7 +73,7 @@ module.exports = async (target, options) => {
 		if (options.app) {
 			command = options.app;
 		} else {
-			// when bundled by webpack there's no installed module and no xdg_open
+			// When bundled by webpack there's no installed module and no xdg_open
 			// we detect this looking at the module installation directory
 			// this will work with the default webpack configuration
 			// if node.__dirname is set to false this won't work, you should either package xdg-open or set options.app

--- a/index.js
+++ b/index.js
@@ -73,12 +73,9 @@ module.exports = async (target, options) => {
 		if (options.app) {
 			command = options.app;
 		} else {
-			// When bundled by webpack there's no installed module and no xdg_open
-			// we detect this looking at the module installation directory
-			// this will work with the default webpack configuration
-			// if node.__dirname is set to false this won't work, you should either package xdg-open or set options.app
-			// Not clear whether this will work for other packagers
+			// When bundled by Webpack, there's no actual package file path and no local `xdg-open`.
 			const isBundled = !__dirname || __dirname === '/';
+
 			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || isBundled;
 			command = useSystemXdgOpen ? 'xdg-open' : path.join(__dirname, 'xdg-open');
 		}

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = async (target, options) => {
 		if (options.app) {
 			command = options.app;
 		} else {
-			const useSystemXdgOpen = process.versions.electron || process.platform === 'android';
+			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || __dirname === '/';
 			command = useSystemXdgOpen ? 'xdg-open' : path.join(__dirname, 'xdg-open');
 		}
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const {promisify} = require('util');
+const { promisify } = require('util');
 const path = require('path');
 const childProcess = require('child_process');
 const isWsl = require('is-wsl');
@@ -9,7 +9,7 @@ const pExecFile = promisify(childProcess.execFile);
 // Convert a path from WSL format to Windows format:
 // `/mnt/c/Program Files/Example/MyApp.exe` → `C:\Program Files\Example\MyApp.exe``
 const wslToWindowsPath = async path => {
-	const {stdout} = await pExecFile('wslpath', ['-w', path]);
+	const { stdout } = await pExecFile('wslpath', ['-w', path]);
 	return stdout.trim();
 };
 
@@ -73,7 +73,13 @@ module.exports = async (target, options) => {
 		if (options.app) {
 			command = options.app;
 		} else {
-			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || __dirname === '/';
+			// when bundled by webpack there's no installed module and no xdg_open
+			// we detect this looking at the module installation directory
+			// this will work with the default webpack configuration
+			// if node.__dirname is set to false this won't work, you should either package xdg-open or set options.app
+			// Not clear whether this will work for other packagers
+			const isBundled = !__dirname || __dirname === '/';
+			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || isBundled;
 			command = useSystemXdgOpen ? 'xdg-open' : path.join(__dirname, 'xdg-open');
 		}
 


### PR DESCRIPTION
Just default to system xdg-open when __dirname = '/' on top of previous cases.

This happens when the code is packaged, as by default xdg-open is not included (and anyway wouldn't be in /)

Fixes #133 