### PR TITLE
Add an option to always use system xdg-open instead of bundled version

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,17 @@ declare namespace open {
 		You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 		*/
 		readonly app?: string | readonly string[];
+
+		/**
+		Use system xdg-open instead of the version included.
+
+		When disabled (which is default), the system xdg-open will only be used if running in Electron, if running in Android or if the package is bundled by Webpack.
+
+		This setting is only used when xdg-open will be used.
+
+		@default false
+		*/
+		readonly useSystemXdgOpen?: boolean;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = async (target, options) => {
 	options = {
 		wait: false,
 		background: false,
+		useSystemXdgOpen: false,
 		...options
 	};
 
@@ -76,7 +77,7 @@ module.exports = async (target, options) => {
 			// When bundled by Webpack, there's no actual package file path and no local `xdg-open`.
 			const isBundled = !__dirname || __dirname === '/';
 
-			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || isBundled;
+			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || isBundled || options.useSystemXdgOpen;
 			command = useSystemXdgOpen ? 'xdg-open' : path.join(__dirname, 'xdg-open');
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,17 @@ The app name is platform dependent. Don't hard code it in reusable modules. For 
 
 You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 
+##### useSystemXdgOpen
+
+Type: `boolean`<br>
+Default: `false`
+
+Use system xdg-open instead of the version included.
+
+When disabled (which is default), the system xdg-open will only be used if running in Electron, if running in Android or if the package is bundled by Webpack.
+
+This setting is only used when xdg-open will be used.
+
 
 ## Related
 


### PR DESCRIPTION
Adds a new option `useSystemXdgOpen` which allows for always using the system `xdg-open` command over the included version.

This is neccessary in some environments when the package thinks it can execute the included version when it actually cannot. One example is when the package is included in a binary produced by a node.js binary compiler like [nbin](https://github.com/cdr/nbin).