### PR TITLE
Add executable check for local xdg-open

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@
 const {promisify} = require('util');
 const path = require('path');
 const childProcess = require('child_process');
-const isExe = require('executable');
+const fs = require('fs');
 const isWsl = require('is-wsl');
 
+const pAccess = promisify(fs.access);
 const pExecFile = promisify(childProcess.execFile);
 
 // Path to included `xdg-open`
@@ -83,7 +84,8 @@ module.exports = async (target, options) => {
 			// Check if local `xdg-open` exists and is executable.
 			let exeLocalXdgOpen = false;
 			try {
-				exeLocalXdgOpen = await isExe(localXdgOpenPath);
+				await pAccess(localXdgOpenPath, fs.constants.X_OK);
+				exeLocalXdgOpen = true;
 			} catch (error) {}
 
 			const useSystemXdgOpen = process.versions.electron ||

--- a/index.js
+++ b/index.js
@@ -2,12 +2,16 @@
 const {promisify} = require('util');
 const path = require('path');
 const childProcess = require('child_process');
+const isExe = require('executable');
 const isWsl = require('is-wsl');
 
 const pExecFile = promisify(childProcess.execFile);
 
+// Path to included `xdg-open`
+const localXdgOpenPath = path.join(__dirname, 'xdg-open');
+
 // Convert a path from WSL format to Windows format:
-// `/mnt/c/Program Files/Example/MyApp.exe` → `C:\Program Files\Example\MyApp.exe``
+// `/mnt/c/Program Files/Example/MyApp.exe` → `C:\Program Files\Example\MyApp.exe`
 const wslToWindowsPath = async path => {
 	const {stdout} = await pExecFile('wslpath', ['-w', path]);
 	return stdout.trim();
@@ -76,8 +80,15 @@ module.exports = async (target, options) => {
 			// When bundled by Webpack, there's no actual package file path and no local `xdg-open`.
 			const isBundled = !__dirname || __dirname === '/';
 
-			const useSystemXdgOpen = process.versions.electron || process.platform === 'android' || isBundled;
-			command = useSystemXdgOpen ? 'xdg-open' : path.join(__dirname, 'xdg-open');
+			// Check if local `xdg-open` exists and is executable.
+			let exeLocalXdgOpen = false;
+			try {
+				exeLocalXdgOpen = await isExe(localXdgOpenPath);
+			} catch (error) {}
+
+			const useSystemXdgOpen = process.versions.electron ||
+				process.platform === 'android' || isBundled || !exeLocalXdgOpen;
+			command = useSystemXdgOpen ? 'xdg-open' : localXdgOpenPath;
 		}
 
 		if (appArguments.length > 0) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"file"
 	],
 	"dependencies": {
+		"executable": "^4.1.1",
 		"is-wsl": "^1.1.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"file"
 	],
 	"dependencies": {
-		"executable": "^4.1.1",
 		"is-wsl": "^1.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Uses the [executable](https://github.com/kevva/executable) package to ensure that the local/included `xdg-open` is executable. If it's not executable (or there was some other error checking if it was executable, for example `ENOENT`), it will fall back to system `xdg-open` instead.

This allows for use within environments where `open` thought it could run the bundled `xdg-open` but it actually can't, such as in binaries produced by a node.js binary compiler like [nbin](https://github.com/cdr/nbin).

Inspired by https://github.com/sindresorhus/open/pull/138#issuecomment-497332488.