### PR TITLE
Handle URL and paths escaping in Windows

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,17 @@ declare namespace open {
 		You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 		*/
 		readonly app?: string | readonly string[];
+
+		/**
+		Uses `encodeURI` to encode the `target` before executing it.
+
+		The use with targets that are not URLs is not recommended.
+
+		Especially useful when dealing with the [double-quotes on Windows](https://github.com/sindresorhus/open#double-quotes-on-windows) caveat.
+
+		@default false
+		*/
+		readonly url?: boolean;
 	}
 }
 
@@ -38,6 +49,8 @@ declare namespace open {
 Open stuff like URLs, files, executables. Cross-platform.
 
 Uses the command `open` on OS X, `start` on Windows and `xdg-open` on other platforms.
+
+There is a caveat for [double-quotes on Windows](https://github.com/sindresorhus/open#double-quotes-on-windows) where all double-quotes are stripped from the `target`.
 
 @param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. For example, URLs open in your default browser.
 @returns The [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = async (target, options) => {
 		}
 	} else if (process.platform === 'win32' || isWsl) {
 		command = 'cmd' + (isWsl ? '.exe' : '');
-		cliArguments.push('/c', 'start', '""', '/b');
+		cliArguments.push('/s', '/c', 'start', '""', '/b');
 
 		// Always quoting target allows for URLs/paths to have spaces and unmarked characters, as `cmd.exe` will
 		// interpret them as plain text to be forwarded as one unique argument. Enabling `windowsVerbatimArguments`

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = async (target, options) => {
 	options = {
 		wait: false,
 		background: false,
+		url: false,
 		...options
 	};
 
@@ -37,6 +38,13 @@ module.exports = async (target, options) => {
 	if (Array.isArray(options.app)) {
 		appArguments = options.app.slice(1);
 		options.app = options.app[0];
+	}
+
+	// Encodes the target as if it were an URL. Especially useful to get
+	// double-quotes through the double-quotes on windows caveat, but it
+	// can be used in any platform.
+	if (options.url) {
+		target = encodeURI(target);
 	}
 
 	if (process.platform === 'darwin') {
@@ -61,6 +69,8 @@ module.exports = async (target, options) => {
 		// interpret them as plain text to be forwarded as one unique argument. Enabling `windowsVerbatimArguments`
 		// disables Node.js's default quotes and escapes handling (https://git.io/fjdem).
 		// References: Issues #17, #44, #55, #77, #101 and #115 / Pull requests: #74 and #98
+		//
+		// As a result, all double-quotes are stripped from the `target` and do not get to your desired destination.
 		target = `"${target}"`;
 		childProcessOptions.windowsVerbatimArguments = true;
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,13 @@ module.exports = async (target, options) => {
 	} else if (process.platform === 'win32' || isWsl) {
 		command = 'cmd' + (isWsl ? '.exe' : '');
 		cliArguments.push('/c', 'start', '""', '/b');
-		target = target.replace(/&/g, '^&');
+
+		// Always quoting target allows for urls/paths to have spaces and unmarked characters, as cmd will
+		// interpret them as plain text to be forwarded as one unique argument. Enabling windowsVerbatimArguments
+		// disables node's default quotes and escapes handling (https://git.io/fjdem).
+		// References: Issues #17, #44, #55, #77, #101 and #115 / Pull requests: #74 and #98
+		target = `"${target}"`;
+		childProcessOptions.windowsVerbatimArguments = true;
 
 		if (options.wait) {
 			cliArguments.push('/wait');

--- a/index.js
+++ b/index.js
@@ -57,9 +57,9 @@ module.exports = async (target, options) => {
 		command = 'cmd' + (isWsl ? '.exe' : '');
 		cliArguments.push('/c', 'start', '""', '/b');
 
-		// Always quoting target allows for urls/paths to have spaces and unmarked characters, as cmd will
-		// interpret them as plain text to be forwarded as one unique argument. Enabling windowsVerbatimArguments
-		// disables node's default quotes and escapes handling (https://git.io/fjdem).
+		// Always quoting target allows for URLs/paths to have spaces and unmarked characters, as `cmd.exe` will
+		// interpret them as plain text to be forwarded as one unique argument. Enabling `windowsVerbatimArguments`
+		// disables Node.js's default quotes and escapes handling (https://git.io/fjdem).
 		// References: Issues #17, #44, #55, #77, #101 and #115 / Pull requests: #74 and #98
 		target = `"${target}"`;
 		childProcessOptions.windowsVerbatimArguments = true;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,3 +9,4 @@ expectType<Promise<ChildProcess>>(open('foo', {app: 'bar'}));
 expectType<Promise<ChildProcess>>(open('foo', {app: ['bar', '--arg']}));
 expectType<Promise<ChildProcess>>(open('foo', {wait: true}));
 expectType<Promise<ChildProcess>>(open('foo', {background: true}));
+expectType<Promise<ChildProcess>>(open('foo', {url: true}));

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,39 @@ The app name is platform dependent. Don't hard code it in reusable modules. For 
 
 You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 
+##### url
+
+Type: `boolean`<br>
+Default: `false`
+
+Uses `encodeURI` to encode the target before executing it.<br>
+We do not recommend using it on targets that are not URLs.
+
+Especially useful when dealing with the [double-quotes on Windows](#double-quotes-on-windows) caveat.
+
+## Caveats
+
+### Double-quotes on Windows
+TL;DR: All double-quotes are stripped from the `target` and do not get to your desired destination (on Windows!).
+
+Due to specific behaviors of Window's Command Prompt (`cmd.exe`) regarding ampersand (`&`) characters breaking commands and URLs, double-quotes are now a special case.
+
+The solution ([#146](https://github.com/sindresorhus/open/pull/146)) to this and other problems was to leverage the fact that `cmd.exe` interprets a double-quoted argument as a plain text argument just by quoting it (like Node already does). Unfortunatelly `cmd.exe` can only do **one** of two things: handle them all **OR** not handle them at all. As per its own documentation:
+
+>*If /C or /K is specified, then the remainder of the command line after the switch is processed as a command line, where the following logic is used to process quote (") characters:*
+>
+>    1.  *If all of the following conditions are met, then quote characters on the command line are preserved:*
+>        - *no /S switch*
+>        - *exactly two quote characters*
+>        - *no special characters between the two quote characters, where special is one of: &<>()@^|*
+>        - *there are one or more whitespace characters between the two quote characters*
+>        - *the string between the two quote characters is the name of an executable file.*
+>
+>    2.  *Otherwise, old behavior is to see if the first character is a quote character and if so, strip the leading character and remove the last quote character on the command line, preserving any text after the last quote character.*
+
+The option that solved all of the problems was the second one, and for additional behavior consistency we're also now using the `/S` switch, so we **always** get the second option. The caveat is that this built-in double-quotes handling ends up stripping all of them from the command line and so far we weren't able to find a scaping method that works (if you do, please feel free to contribute!).
+
+To make this caveat somewhat less impactful (at least for URLs), check out the [url option](#url). Double-quotes will be "preserved" when using it with an URL.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -33,6 +33,10 @@ test('wait for the app to close if wait: true', async () => {
 	await open('https://sindresorhus.com', {wait: true});
 });
 
+test('encode url if url: true', async () => {
+	await open('https://sindresorhus.com', {url: true});
+});
+
 test('open url in default app', async () => {
 	await open('https://sindresorhus.com');
 });

--- a/test.js
+++ b/test.js
@@ -50,6 +50,30 @@ test('return the child process when called', async t => {
 	t.true('stdout' in cp);
 });
 
+test('open url with query strings', async () => {
+	await open('https://sindresorhus.com/?abc=123&def=456');
+});
+
+test('open url with a fragment', async () => {
+	await open('https://sindresorhus.com#projects');
+});
+
+test('open url with query strings and spaces', async () => {
+	await open('https://sindresorhus.com/?abc=123&def=456&ghi=with spaces');
+});
+
+test('open url with query strings and a fragment', async () => {
+	await open('https://sindresorhus.com/?abc=123&def=456#projects');
+});
+
+test('open url with query strings and pipes', async () => {
+	await open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h');
+});
+
+test('open url with query strings, spaces, pipes and a fragment', async () => {
+	await open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h spaces#projects');
+});
+
 if (isWsl) {
 	test('open url in specified windows app given a wsl path to the app', async () => {
 		await open('https://sindresorhus.com', {app: firefoxWslName});


### PR DESCRIPTION
This fixes an old problem that has been widely reported but haven't had a simple and concrete solution yet. This is my attempt on making it happen 🙃

**To sum up the problem:** on windows, ampersand (`&`) characters were being escaped with caret (`^`) characters due to windows's cmd interpreting them as a command would break (as in command not found) or would forward a partial argument only (as in URLs with query arguments that contain spaces).

**The solution:** JavaScript's standard `encodeURI` function would solve the problem for URLs, but not for file paths (especially on windows). So we leverage the fact that window's `cmd` interprets a double-quoted argument as a plain text argument just by quoting it (like Node already does). For that to be consistent we need to disable [Node's default quoting and escaping behavior (which is conditional)](https://git.io/fjdem) with its own `windowsVerbatimArguments` flag, and do it ourselves.

Tested in Windows with both Google Chrome and Internet Explorer, using query strings, spaces, pipes, fragments and multiple combinations of all of them.

 - **Fixes #17:** URL fragments
 - **Fixes #44:** URL query strings (ampersand escaping)
 - **Fixes #55:** URL query strings with local HTML files (ampersand escaping)
 - **Fixes #77:** File system path (ampersand escaping)
 - **Fixes #101:** URL query strings with local HTML files (ampersand escaping)
 - **Fixes #115:** Shell option is not needed since windowsVerbatimArguments is now used explicitly
 - **Resolves #74:** File system path (ampersand escaping)
 - **Resolves #98:** URL with pipe characters


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#115: Use the `childProcess.spawn` `shell` option on Windows and fix the quote issue](https://issuehunt.io/repos/18469325/issues/115)
- [#77: on windows, can't opn a directory with an ampersand](https://issuehunt.io/repos/18469325/issues/77)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->