### PR TITLE
Update `is-wsl` dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"file"
 	],
 	"dependencies": {
-		"is-wsl": "^1.1.0"
+		"is-wsl": "^2.1.0"
 	},
 	"devDependencies": {
 		"@types/node": "^11.13.6",


### PR DESCRIPTION
Updated `is-wsl` dependency to current _2.1.0_ release version to support wsl 2.0