### PR TITLE
Fix arg without double-quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = async (target, options) => {
 				options.app = windowsPath;
 			}
 
-			cliArguments.push(options.app);
+			cliArguments.push(`"${options.app}"`);
 		}
 
 		if (appArguments.length > 0) {


### PR DESCRIPTION
Fixes #158

Currently, we have this problem():
![image](https://user-images.githubusercontent.com/19208123/71668441-869f7780-2d9b-11ea-88c4-5a4c0258dd58.png)

So I add double-quotes for `options.app`