### PR TITLE
Fix Docker in WSL2

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const isWsl = require('is-wsl');
+const isDocker = require('is-docker');
 
 const pAccess = promisify(fs.access);
 const pExecFile = promisify(childProcess.execFile);
@@ -61,7 +62,7 @@ module.exports = async (target, options) => {
 		if (options.app) {
 			cliArguments.push('-a', options.app);
 		}
-	} else if (process.platform === 'win32' || isWsl) {
+	} else if (process.platform === 'win32' || (isWsl && !isDocker)) {
 		command = 'cmd' + (isWsl ? '.exe' : '');
 		cliArguments.push('/s', '/c', 'start', '""', '/b');
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"file"
 	],
 	"dependencies": {
+		"is-docker": "^2.0.0",
 		"is-wsl": "^2.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
When running the new experimental docker for desktop (Windows) in WSL2 open assumes that is has access to windows .exe files, which does not work in the context of docker. This uses the is-docker lib to revert to linux behavior in this case but still run things correctly if you're using WSL 1 or 2 outside of docker.

Fixes #157 