### PR TITLE
Fix Docker in WSL2 for real

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const isWsl = require('is-wsl');
-const isDocker = require('is-docker')();
+const isDocker = require('is-docker');
 
 const pAccess = promisify(fs.access);
 const pExecFile = promisify(childProcess.execFile);
@@ -62,7 +62,7 @@ module.exports = async (target, options) => {
 		if (options.app) {
 			cliArguments.push('-a', options.app);
 		}
-	} else if (process.platform === 'win32' || (isWsl && !isDocker)) {
+	} else if (process.platform === 'win32' || (isWsl && !isDocker())) {
 		command = 'cmd' + (isWsl ? '.exe' : '');
 		cliArguments.push('/s', '/c', 'start', '""', '/b');
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const isWsl = require('is-wsl');
-const isDocker = require('is-docker');
+const isDocker = require('is-docker')();
 
 const pAccess = promisify(fs.access);
 const pExecFile = promisify(childProcess.execFile);


### PR DESCRIPTION
The module exports a function, not a boolean, so the check for its value would always pass. This breaks WSL (again). We don't need to call the function more than once to find out if we're in docker, so this just calls it right on require.

Fixes the bug introduced in #164.

`<snark>`This wouldn't have happened with TypeScript. ;)`</snark>`