### PR TITLE
Fix `app` option on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,9 @@ module.exports = async (target, options) => {
 			// As a result, all double-quotes are stripped from the `target` and do not get to your desired destination.
 			target = `"${target}"`;
 			childProcessOptions.windowsVerbatimArguments = true;
+			if (options.app) {
+				options.app = `"${options.app}"`;
+			}
 		}
 
 		if (options.wait) {

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ module.exports = async (target, options) => {
 			// As a result, all double-quotes are stripped from the `target` and do not get to your desired destination.
 			target = `"${target}"`;
 			childProcessOptions.windowsVerbatimArguments = true;
+
 			if (options.app) {
 				options.app = `"${options.app}"`;
 			}


### PR DESCRIPTION
Reopen #162

I moved check `isWsl` in `if (!isWsl)` 

https://github.com/Hongarc/open/commit/3530dcd061498b597819fd21ed00282b082989dd


Should I keep check it in `if(options.app)`