### PR TITLE
fix: pnp compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"engines": {
 		"node": ">=8"
 	},
+	"preferUnplugged": true,
 	"scripts": {
 		"test": "xo && tsd"
 	},


### PR DESCRIPTION
**What's the problem this PR addresses?**

`open` currently doesn't work on Linux under Yarn PnP without users manually telling yarn to unplug the package.

Fixes https://github.com/sindresorhus/open/issues/169

**How did you fix it?**

Set `preferUnplugged: true` in the manifest to tell yarn to always unplug(unzip) the package