### PR TITLE
Add `newWindow` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,16 +21,16 @@ declare namespace open {
 
 		@default false
 		*/
-    readonly background?: boolean;
-    
-    /**
-    __macOS only__
+		readonly background?: boolean;
 
-    Open the specified url in a new window. This is useful when the app is expected to already be open.
+		/**
+		__macOS only__
 
-    @default false
-    */
-    readonly newWindow?: boolean;
+		Open the specified url in a new window. This is useful when the app is expected to already be open.
+
+		@default false
+		*/
+		readonly newWindow?: boolean;
 
 		/**
 		Specify the app to open the `target` with, or an array with the app and app arguments.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,16 @@ declare namespace open {
 
 		@default false
 		*/
-		readonly background?: boolean;
+    readonly background?: boolean;
+    
+    /**
+    __macOS only__
+
+    Open the specified url in a new window. This is useful when the app is expected to already be open.
+
+    @default false
+    */
+    readonly newWindow?: boolean;
 
 		/**
 		Specify the app to open the `target` with, or an array with the app and app arguments.

--- a/index.js
+++ b/index.js
@@ -148,11 +148,11 @@ module.exports = async (target, options) => {
 		}
 	}
 
-	cliArguments.push(target);
+  if (process.platform === 'darwin' && appArguments.length > 0) {
+    cliArguments.push('--args', ...appArguments);
+  }
 
-	if (process.platform === 'darwin' && appArguments.length > 0) {
-		cliArguments.push('--args', ...appArguments);
-	}
+  cliArguments.push(target);
 
 	const subprocess = childProcess.spawn(command, cliArguments, childProcessOptions);
 

--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ module.exports = async (target, options) => {
 	options = {
 		wait: false,
 		background: false,
-    newWindow: false,
-    allowNonzeroExitCode: false,
+		newWindow: false,
+		allowNonzeroExitCode: false,
 		...options
 	};
 
@@ -66,18 +66,18 @@ module.exports = async (target, options) => {
 			cliArguments.push('--background');
 		}
 
-    if (options.newWindow) {
-      cliArguments.push('-n');
-    }
+		if (options.newWindow) {
+			cliArguments.push('-n');
+		}
 
 		if (app) {
 			cliArguments.push('-a', app);
-    }
-    
-    if(appArguments.length > 0) {
-      cliArguments.push('--args', ...appArguments);
-    }
-    
+		}
+		
+		if(appArguments.length > 0) {
+			cliArguments.push('--args', ...appArguments);
+		}
+		
 	} else if (process.platform === 'win32' || (isWsl && !isDocker())) {
 		const windowsRoot = isWsl ? await wslGetWindowsEnvVar('systemroot') : process.env.SYSTEMROOT;
 		command = String.raw`${windowsRoot}\System32\WindowsPowerShell\v1.0\powershell${isWsl ? '.exe' : ''}`;
@@ -153,7 +153,7 @@ module.exports = async (target, options) => {
 		}
 	}
 
-  cliArguments.push(target);
+	cliArguments.push(target);
 
 	const subprocess = childProcess.spawn(command, cliArguments, childProcessOptions);
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ module.exports = async (target, options) => {
 	options = {
 		wait: false,
 		background: false,
-		allowNonzeroExitCode: false,
+    newWindow: false,
+    allowNonzeroExitCode: false,
 		...options
 	};
 
@@ -64,6 +65,10 @@ module.exports = async (target, options) => {
 		if (options.background) {
 			cliArguments.push('--background');
 		}
+
+    if (options.newWindow) {
+      cliArguments.push('-n');
+    }
 
 		if (app) {
 			cliArguments.push('-a', app);

--- a/index.js
+++ b/index.js
@@ -72,7 +72,12 @@ module.exports = async (target, options) => {
 
 		if (app) {
 			cliArguments.push('-a', app);
-		}
+    }
+    
+    if(appArguments.length > 0) {
+      cliArguments.push('--args', ...appArguments);
+    }
+    
 	} else if (process.platform === 'win32' || (isWsl && !isDocker())) {
 		const windowsRoot = isWsl ? await wslGetWindowsEnvVar('systemroot') : process.env.SYSTEMROOT;
 		command = String.raw`${windowsRoot}\System32\WindowsPowerShell\v1.0\powershell${isWsl ? '.exe' : ''}`;
@@ -147,10 +152,6 @@ module.exports = async (target, options) => {
 			childProcessOptions.detached = true;
 		}
 	}
-
-  if (process.platform === 'darwin' && appArguments.length > 0) {
-    cliArguments.push('--args', ...appArguments);
-  }
 
   cliArguments.push(target);
 

--- a/index.js
+++ b/index.js
@@ -73,11 +73,10 @@ module.exports = async (target, options) => {
 		if (app) {
 			cliArguments.push('-a', app);
 		}
-		
-		if(appArguments.length > 0) {
+
+		if (appArguments.length > 0) {
 			cliArguments.push('--args', ...appArguments);
 		}
-		
 	} else if (process.platform === 'win32' || (isWsl && !isDocker())) {
 		const windowsRoot = isWsl ? await wslGetWindowsEnvVar('systemroot') : process.env.SYSTEMROOT;
 		command = String.raw`${windowsRoot}\System32\WindowsPowerShell\v1.0\powershell${isWsl ? '.exe' : ''}`;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,4 +9,5 @@ expectType<Promise<ChildProcess>>(open('foo', {app: 'bar'}));
 expectType<Promise<ChildProcess>>(open('foo', {app: ['bar', '--arg']}));
 expectType<Promise<ChildProcess>>(open('foo', {wait: true}));
 expectType<Promise<ChildProcess>>(open('foo', {background: true}));
+expectType<Promise<ChildProcess>>(open('foo', {newWindow: true}));
 expectType<Promise<ChildProcess>>(open('foo', {url: true}));

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"file"
 	],
 	"dependencies": {
+		"child_process": "^1.0.2",
 		"is-docker": "^2.0.0",
 		"is-wsl": "^2.1.1"
 	},

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,13 @@ Default: `false`
 
 Do not bring the app to the foreground.
 
+##### newWindow <sup>(macOS only)</sup>
+
+Type: `boolean`\
+Default: `false`
+
+Open the specified url in a new window. This is useful when the app is expected to already be open.
+
 ##### app
 
 Type: `string | string[]`


### PR DESCRIPTION
Very light feature add here. Added an option for opening an application in a new window. This is useful for when the application is already open.

For example, if attempting to open an incognito window in Google Chrome (see #41 ), the proper command in a Mac OS terminal would be:

`open -n -a "Google Chrome" "$url" --args --incognito`

This should solve #41 by allowing users to use this tool to execute that command.

--------------------

EDIT: upon further testing, I've found that the url param in the above command (`"$url"`) must be placed last:
`open -n -a "Google Chrome" --args --incognito "$url"`

I'm adding that change to this PR.