### PR TITLE
Fix support for WSL when Windows isn't mounted in `/mnt/`

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = async (target, options) => {
 		}
 
 		if (app) {
-			if (isWsl && app.startsWith('/mnt/')) {
+			if (isWsl && app.startsWith('/')) {
 				const windowsPath = await wslToWindowsPath(app);
 				app = windowsPath;
 			}


### PR DESCRIPTION
In WSL, Windows drives aren't always mounted in `/mnt/` – you can specify the mount location via the `root` key in `wsl.conf`. For this reason I replaced the check that verifies the `app` path starts with `/mnt/` with a check that simply looks for `/` at the start to see if it's a Linux path.

I don't know if the current `/mnt/` check was added to handle some specific edge cases, but I think changing it should be ok.