### PR TITLE
preferUnplugged: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
 		"ava": "^2.3.0",
 		"tsd": "^0.11.0",
 		"xo": "^0.25.3"
-	}
+	},
+	"preferUnplugged": true
 }


### PR DESCRIPTION
TL;DR: Using `yarn` version `berry` seems incompatible with package `open` using default PnP settings.

# Context

I ran into a problem using [`storybook`](https://www.learnstorybook.com/). `storybook` starts a webserver on a certain port using a library which calls `open`. I'm using `yarn` version `berry` (`v2.4.0`) which stores all packages in zipped form (PnP). This seems to be incompatible with the behavior of spawning a new child process with `open`. I obtained the following traceback:

```
➜  charm-prospector git:(john/cleanup) ✗ yarn storybook
info @storybook/react v6.1.11
info 
info => Using prebuilt manager
info => Loading presets
info => Loading 1 config file in "./.storybook"
info => Loading 7 other files in "./.storybook"
info => Adding stories defined in ".storybook/main.js"
info => Using default Webpack setup
webpack built 9cb17c8972c4de8382bf in 6707ms
╭────────────────────────────────────────────────╮
│                                                │
│   Storybook 6.1.11 started                     │
│   8.3 s for preview                            │
│                                                │
│    Local:            http://localhost:6006/    │
│    On your network:  http://10.0.2.15:6006/    │
│                                                │
╰────────────────────────────────────────────────╯
node:internal/child_process:403
    throw errnoException(err, 'spawn');
          ^

Error: spawn ENOTDIR
    at ChildProcess.spawn (node:internal/child_process:403:11)
    at Object.spawn (node:child_process:573:9)
    at module.exports (/home/john/Downloads/repos/charm-prospector/.yarn/cache/open-npm-7.3.0-d582d8b42e-a212fc9cf6.zip/node_modules/open/index.js:152:34)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:93:5) {
  errno: -20,
  code: 'ENOTDIR',
  syscall: 'spawn'
}
```

This seems to be related to https://github.com/yarnpkg/berry/issues/856.

I've managed to fix this problem by adding `preferUnplugged: true` to your `package.json`. When I instruct `yarn` to use my fork with this fix everything works fine:

```package.json
  ....
  "resolutions": {
    "open": "johnrichardrinehart/open#john/prefer-unplugged"
  }
```

```
➜  charm-prospector git:(john/cleanup) ✗ yarn storybook
info @storybook/react v6.1.11
info 
info => Using prebuilt manager
info => Loading presets
info => Loading 1 config file in "./.storybook"
info => Loading 7 other files in "./.storybook"
info => Adding stories defined in ".storybook/main.js"
info => Using default Webpack setup
webpack built 9cb17c8972c4de8382bf in 8392ms
╭────────────────────────────────────────────────╮
│                                                │
│   Storybook 6.1.11 started                     │
│   9.64 s for preview                           │
│                                                │
│    Local:            http://localhost:6006/    │
│    On your network:  http://10.0.2.15:6006/    │
│                                                │
╰────────────────────────────────────────────────╯
  
```

No error, here.
