### PR TITLE
WSL: Get drives mount point from wsl.conf

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,13 @@ const getWslDrivesMountPoint = (() => {
 
 		const configFilePath = '/etc/wsl.conf';
 
-		if (!fs.existsSync(configFilePath)) {
+		let isConfigFileExists = false;
+		try {
+			await pAccess(configFilePath, fs.constants.F_OK);
+			isConfigFileExists = true;
+		} catch (_) {}
+
+		if (!isConfigFileExists) {
 			// Default value for "root" param
 			// according to https://docs.microsoft.com/en-us/windows/wsl/wsl-config
 			return '/mnt/';

--- a/index.js
+++ b/index.js
@@ -24,9 +24,13 @@ const getWslMountPoint = async () => {
 
 	if (fs.existsSync(confFile)) {
 		const conf = await pReadFile(confFile, {encoding: 'utf-8'});
-		const value = /root\s*=\s*(.*)/g.exec(conf)[1];
+		const value = (/root\s*=\s*(.*)/g.exec(conf)[1] || '').trim();
 
-		return value;
+		if (!!value) {
+			return  value.endsWith('/')
+				? value
+				: value.concat('/');
+		}
 	}
 
 	// Default value for "root" param

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const getWslDrivesMountPoint = (() => {
 			return '/mnt/';
 		}
 
-		const configContent = await pReadFile(configFilePath, {encoding: 'utf-8'});
+		const configContent = await pReadFile(configFilePath, {encoding: 'utf8'});
 
 		mountPoint = (/root\s*=\s*(.*)/g.exec(configContent)[1] || '').trim();
 		mountPoint = mountPoint.endsWith('/') ? mountPoint : mountPoint + '/';

--- a/index.js
+++ b/index.js
@@ -12,11 +12,11 @@ const pAccess = promisify(fs.access);
 const localXdgOpenPath = path.join(__dirname, 'xdg-open');
 
 /**
- * Returns the mount point for fixed drives in WSL
- *
- * @inner
- * @returns {string} Mount point
- */
+Get the mount point for fixed drives in WSL.
+
+@inner
+@returns {string} The mount point.
+*/
 const getWslDrivesMountPoint = (() => {
 	let mountPoint = null;
 

--- a/index.js
+++ b/index.js
@@ -26,10 +26,8 @@ const getWslMountPoint = async () => {
 		const conf = await pReadFile(confFile, {encoding: 'utf-8'});
 		const value = (/root\s*=\s*(.*)/g.exec(conf)[1] || '').trim();
 
-		if (!!value) {
-			return  value.endsWith('/')
-				? value
-				: value.concat('/');
+		if (value) {
+			return value.endsWith('/') ? value : value.concat('/');
 		}
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Note: The original [`open` package](https://github.com/pwnall/node-open) was pre
 - Safer as it uses `spawn` instead of `exec`.
 - Fixes most of the open original `node-open` issues.
 - Includes the latest [`xdg-open` script](https://cgit.freedesktop.org/xdg/xdg-utils/commit/?id=c55122295c2a480fa721a9614f0e2d42b2949c18) for Linux.
-- Supports WSL paths to Windows apps under `/mnt/*`.
+- Supports WSL paths to Windows apps.
 
 ## Install
 
@@ -108,7 +108,7 @@ Type: `boolean`\
 Default: `false`
 
 Allow the opened app to exit with nonzero exit code when the `wait` option is `true`.
-		
+
 We do not recommend setting this option. The convention for success is exit code zero.
 
 ## Caveats


### PR DESCRIPTION
The drives mount point for WSL defined as constant at now. See issue #218. 
This PR will fix it by getting drives mount point dynamically from `wsl.conf` file.