### PR TITLE
Windows: Fix error with forward slashes in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = async (target, options) => {
 			encodedArguments.push(`"\`"${app}\`""`, '-ArgumentList');
 			appArguments.unshift(target);
 		} else {
-			encodedArguments.push(`"\`"${target}\`""`);
+			encodedArguments.push(`"${target}"`);
 		}
 
 		if (appArguments.length > 0) {


### PR DESCRIPTION
This PR will fix #214 issue. The error happens if in the `-FilePath` parameter for `Start-Process` cmdlet contains the escaped quotation character. So just need to not add it.