### PR TITLE
Replace deprecated API regarding Electron tip

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 This is meant to be used in command-line tools and scripts, not in the browser.
 
-If you need this for Electron, use [`shell.openItem()`](https://electronjs.org/docs/api/shell#shellopenitemfullpath) instead.
+If you need this for Electron, use [`shell.openPath()`](https://www.electronjs.org/docs/api/shell#shellopenpathpath) instead.
 
 Note: The original [`open` package](https://github.com/pwnall/node-open) was previously deprecated in favor of this package, and we got the name, so this package is now named `open` instead of `opn`. If you're upgrading from the original `open` package (`open@0.0.5` or lower), keep in mind that the API is different.
 


### PR DESCRIPTION
`shell.openItem()` -> `shell.openPath()`

https://github.com/electron/governance/blob/master/wg-api/spec-documents/shell-openitem.md