### PR TITLE
Require Node.js 10.17, add `.apps` and allow multiple apps to be tried

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
         node-version:
           - 14
           - 12
-          - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
         node-version:
           - 14
           - 12
+          - 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,11 +24,11 @@ declare namespace open {
 		readonly background?: boolean;
 
 		/**
-	Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try. If each app fails, the last error will be thrown.
+		Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try. If each app fails, the last error will be thrown.
 
-	The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
+		The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
 
-	You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
+		You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 		*/
 		readonly app?: App | readonly App[];
 
@@ -47,7 +47,7 @@ declare namespace open {
 
 declare const open: {
 	/**
-	An object containing auto-detected binary names for common apps. Useful to work around cross-platform issues.
+	An object containing auto-detected binary names for common apps. Useful to work around cross-platform differences.
 
 	@example
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ declare const open: {
 	});
 	```
 	*/
-	apps: Record<AppName, string | string[]>;
+	apps: Record<open.AppName, string | string[]>;
 
 	/**
 	Open stuff like URLs, files, executables. Cross-platform.

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,11 @@ declare namespace open {
 		readonly allowNonzeroExitCode?: boolean;
 	}
 
-	type App = {name: string | readonly string[]; arguments?: readonly string[]};
+	type AppName =
+		| 'chrome'
+		| 'firefox';
+
+	type App = {name: AppName | readonly AppName[]; arguments?: readonly string[]};
 }
 
 declare const open: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,42 +30,53 @@ declare namespace open {
 
 		You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 		*/
-		readonly app?: string | readonly string[];
-
-		/**
-		__deprecated__
-
-		This option will be removed in the next major release.
-		*/
-		readonly url?: boolean;
+		readonly app?: App | readonly App[];
 
 		/**
 		Allow the opened app to exit with nonzero exit code when the `wait` option is `true`.
-		
+
 		We do not recommend setting this option. The convention for success is exit code zero.
 
 		@default false
 		*/
 		readonly allowNonzeroExitCode?: boolean;
 	}
+
+	type App = {name: string | readonly string[]; arguments?: readonly string[]};
 }
 
-/**
-Open stuff like URLs, files, executables. Cross-platform.
+declare const open: {
+	/**
+	An object containing auto-detected binary names for common apps. Useful to work around cross-platform issues.
 
-Uses the command `open` on OS X, `start` on Windows and `xdg-open` on other platforms.
+	@example
+	```
+	import open, {apps} from 'open';
 
-There is a caveat for [double-quotes on Windows](https://github.com/sindresorhus/open#double-quotes-on-windows) where all double-quotes are stripped from the `target`.
+	await open('https://google.com', {
+		app: {
+			name: apps.chrome
+		}
+	});
+	```
+	*/
+	apps: Record<string, string>;
 
-@param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. For example, URLs open in your default browser.
-@returns The [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
+	/**
+	Open stuff like URLs, files, executables. Cross-platform.
 
-@example
-```
-import open = require('open');
+	Uses the command `open` on OS X, `start` on Windows and `xdg-open` on other platforms.
 
-// Opens the image in the default image viewer
-(async () => {
+	There is a caveat for [double-quotes on Windows](https://github.com/sindresorhus/open#double-quotes-on-windows) where all double-quotes are stripped from the `target`.
+
+	@param target - The thing you want to open. Can be a URL, file, or executable. Opens in the default app for the file type. For example, URLs open in your default browser.
+	@returns The [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
+
+	@example
+	```
+	import open from 'open';
+
+	// Opens the image in the default image viewer
 	await open('unicorn.png', {wait: true});
 	console.log('The image viewer app closed');
 
@@ -77,12 +88,12 @@ import open = require('open');
 
 	// Specify app arguments
 	await open('https://sindresorhus.com', {app: ['google chrome', '--incognito']});
-})();
-```
-*/
-declare function open(
-	target: string,
-	options?: open.Options
-): Promise<ChildProcess>;
+	```
+	*/
+	(
+		target: string,
+		options?: open.Options
+	): Promise<ChildProcess>;
+};
 
-export = open;
+export default open;

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ declare const open: {
 	});
 	```
 	*/
-	apps: Record<string, string>;
+	apps: Record<string, string | string[]>;
 
 	/**
 	Open stuff like URLs, files, executables. Cross-platform.

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,11 +24,11 @@ declare namespace open {
 		readonly background?: boolean;
 
 		/**
-		Specify the app to open the `target` with, or an array with the app and app arguments.
+	Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try. If each app fails, the last error will be thrown.
 
-		The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows.
+	The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
 
-		You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
+	You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 		*/
 		readonly app?: App | readonly App[];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,11 +83,11 @@ declare const open: {
 	// Opens the url in the default browser
 	await open('https://sindresorhus.com');
 
-	// Specify the app to open in
-	await open('https://sindresorhus.com', {app: 'firefox'});
+	// Opens the URL in a specified browser.
+	await open('https://sindresorhus.com', {app: {name: 'firefox'}});
 
-	// Specify app arguments
-	await open('https://sindresorhus.com', {app: ['google chrome', '--incognito']});
+	// Specify app arguments.
+	await open('https://sindresorhus.com', {app: {name: 'google chrome', arguments: '--incognito'}});
 	```
 	*/
 	(

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,11 +51,11 @@ declare const open: {
 
 	@example
 	```
-	import open, {apps} from 'open';
+	import open = require('open');
 
 	await open('https://google.com', {
 		app: {
-			name: apps.chrome
+			name: open.apps.chrome
 		}
 	});
 	```
@@ -74,7 +74,7 @@ declare const open: {
 
 	@example
 	```
-	import open from 'open';
+	import open = require('open');
 
 	// Opens the image in the default image viewer
 	await open('unicorn.png', {wait: true});
@@ -96,4 +96,4 @@ declare const open: {
 	): Promise<ChildProcess>;
 };
 
-export default open;
+export = open;

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ declare namespace open {
 		| 'chrome'
 		| 'firefox';
 
-	type App = {name: AppName | readonly AppName[]; arguments?: readonly string[]};
+	type App = {name: string | readonly string[]; arguments?: readonly string[]};
 }
 
 declare const open: {
@@ -64,7 +64,7 @@ declare const open: {
 	});
 	```
 	*/
-	apps: Record<string, string | string[]>;
+	apps: Record<AppName, string | string[]>;
 
 	/**
 	Open stuff like URLs, files, executables. Cross-platform.

--- a/index.js
+++ b/index.js
@@ -247,4 +247,4 @@ defineLazyProperty(apps, 'firefox', () => detectPlatformBinary(new Map([
 
 open.apps = apps;
 
-export default open;
+module.exports = open;

--- a/index.js
+++ b/index.js
@@ -53,17 +53,17 @@ const getWslDrivesMountPoint = (() => {
 })();
 
 const pTryEach = async (array, mapper) => {
-	let latestError
+	let latestError;
 
 	for (const item of array) {
 		try {
 			return await mapper(item); // eslint-disable-line no-await-in-loop
 		} catch (error) {
-			latestError = error
+			latestError = error;
 		}
 	}
 
-	throw latestError
+	throw latestError;
 };
 
 const open = async (target, options) => {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const getWslDrivesMountPoint = (() => {
 			return defaultMountPoint;
 		}
 
-		const configContent = await pReadFile(configFilePath, {encoding: 'utf8'});
+		const configContent = await fs.readFile(configFilePath, {encoding: 'utf8'});
 		const configMountPoint = /root\s*=\s*(?<mountPoint>.*)/g.exec(configContent)?.groups?.mountPoint?.trim();
 
 		if (!configMountPoint) {

--- a/index.js
+++ b/index.js
@@ -26,8 +26,6 @@ const getWslDrivesMountPoint = (() => {
 	// according to https://docs.microsoft.com/en-us/windows/wsl/wsl-config
 	const defaultMountPoint = '/mnt/';
 
-	let mountPoint;
-
 	return async function () {
 		if (mountPoint) {
 			// Return memoized mount point value
@@ -47,22 +45,22 @@ const getWslDrivesMountPoint = (() => {
 		}
 
 		const configContent = await fs.readFile(configFilePath, {encoding: 'utf8'});
-		const configMountPoint = /root\s*=\s*(?<mountPoint>.*)/g.exec(configContent)?.groups?.mountPoint?.trim();
+		const configMountPoint = /root\s*=\s*(?<mountPoint>.*)/g.exec(configContent);
 
 		if (!configMountPoint) {
 			return defaultMountPoint;
 		}
 
-		mountPoint = configMountPoint.endsWith('/') ? configMountPoint : `${configMountPoint}/`;
+		const mountPoint = configMountPoint.groups.mountPoint.trim()
 
-		return mountPoint;
+		return mountPoint.endsWith('/') ? mountPoint : `${mountPoint}/`;
 	};
 })();
 
 const pTryEach = async (array, mapper) => {
 	const errors = [];
 
-	for await (const item of array) {
+	for (const item of array) {
 		try {
 			return await mapper(item);
 		} catch (error) {

--- a/index.js
+++ b/index.js
@@ -1,17 +1,13 @@
-import path from 'path';
-import childProcess from 'child_process';
-import {promises as fs} from 'fs';
-import {fileURLToPath} from 'url';
-import isWsl from 'is-wsl';
-import isDocker from 'is-docker';
-import defineLazyProperty from 'define-lazy-prop';
-import AggregateError from 'aggregate-error';
-
-// Node.js ESM doesn't expose __dirname (https://stackoverflow.com/a/50052194/8384910)
-const currentDirectoryName = path.dirname(fileURLToPath(import.meta.url));
+const path = require('path');
+const childProcess = require('child_process');
+const {promises: fs} = require('fs');
+const isWsl = require('is-wsl');
+const isDocker = require('is-docker');
+const defineLazyProperty = require('define-lazy-prop');
+const AggregateError = require('aggregate-error');
 
 // Path to included `xdg-open`.
-const localXdgOpenPath = path.join(currentDirectoryName, 'xdg-open');
+const localXdgOpenPath = path.join(__dirname, 'xdg-open');
 
 const {platform} = process;
 
@@ -51,7 +47,7 @@ const getWslDrivesMountPoint = (() => {
 			return defaultMountPoint;
 		}
 
-		const mountPoint = configMountPoint.groups.mountPoint.trim()
+		const mountPoint = configMountPoint.groups.mountPoint.trim();
 
 		return mountPoint.endsWith('/') ? mountPoint : `${mountPoint}/`;
 	};
@@ -62,7 +58,7 @@ const pTryEach = async (array, mapper) => {
 
 	for (const item of array) {
 		try {
-			return await mapper(item);
+			return await mapper(item); // eslint-disable-line no-await-in-loop
 		} catch (error) {
 			errors.push(error);
 		}
@@ -166,7 +162,7 @@ const open = async (target, options) => {
 			command = app;
 		} else {
 			// When bundled by Webpack, there's no actual package file path and no local `xdg-open`.
-			const isBundled = !currentDirectoryName || currentDirectoryName === '/';
+			const isBundled = !__dirname || __dirname === '/';
 
 			// Check if local `xdg-open` exists and is executable.
 			let exeLocalXdgOpen = false;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const {promises: fs} = require('fs');
 const isWsl = require('is-wsl');
 const isDocker = require('is-docker');
 const defineLazyProperty = require('define-lazy-prop');
-const AggregateError = require('aggregate-error');
 
 // Path to included `xdg-open`.
 const localXdgOpenPath = path.join(__dirname, 'xdg-open');
@@ -54,17 +53,17 @@ const getWslDrivesMountPoint = (() => {
 })();
 
 const pTryEach = async (array, mapper) => {
-	const errors = [];
+	let latestError
 
 	for (const item of array) {
 		try {
 			return await mapper(item); // eslint-disable-line no-await-in-loop
 		} catch (error) {
-			errors.push(error);
+			latestError = error
 		}
 	}
 
-	throw new AggregateError(errors);
+	throw latestError
 };
 
 const open = async (target, options) => {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,12 +1,16 @@
 import {expectType} from 'tsd';
 import {ChildProcess} from 'child_process';
-import open = require('.');
+import open from './index.js';
 
 const options: open.Options = {};
 
 expectType<Promise<ChildProcess>>(open('foo'));
-expectType<Promise<ChildProcess>>(open('foo', {app: 'bar'}));
-expectType<Promise<ChildProcess>>(open('foo', {app: ['bar', '--arg']}));
+expectType<Promise<ChildProcess>>(open('foo', {app: {
+	name: 'bar'
+}}));
+expectType<Promise<ChildProcess>>(open('foo', {app: {
+	name: 'bar',
+	arguments: ['--arg']
+}}));
 expectType<Promise<ChildProcess>>(open('foo', {wait: true}));
 expectType<Promise<ChildProcess>>(open('foo', {background: true}));
-expectType<Promise<ChildProcess>>(open('foo', {url: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,6 @@
 import {expectType} from 'tsd';
 import {ChildProcess} from 'child_process';
-import open from './index.js';
+import open = require('.');
 
 const options: open.Options = {};
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": "^10.17 || >=11.14"
+		"node": "^10.17"
 	},
 	"scripts": {
 		"test": "xo && tsd"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": "^10.17 || >=11.14"
 	},
 	"scripts": {
 		"test": "xo && tsd"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "https://sindresorhus.com"
 	},
-	"type": "module",
 	"engines": {
-		"node": ">=12"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && tsd"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "https://sindresorhus.com"
 	},
+	"type": "module",
 	"engines": {
-		"node": ">=8"
+		"node": ">=12"
 	},
 	"scripts": {
 		"test": "xo && tsd"
@@ -48,13 +49,15 @@
 		"file"
 	],
 	"dependencies": {
-		"is-docker": "^2.0.0",
-		"is-wsl": "^2.1.1"
+		"aggregate-error": "^3.1.0",
+		"define-lazy-prop": "^2.0.0",
+		"is-docker": "^2.1.1",
+		"is-wsl": "^2.2.0"
 	},
 	"devDependencies": {
-		"@types/node": "^12.7.5",
-		"ava": "^2.3.0",
-		"tsd": "^0.11.0",
-		"xo": "^0.25.3"
+		"@types/node": "^14.14.27",
+		"ava": "^3.15.0",
+		"tsd": "^0.14.0",
+		"xo": "^0.37.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 		"file"
 	],
 	"dependencies": {
-		"aggregate-error": "^3.1.0",
 		"define-lazy-prop": "^2.0.0",
 		"is-docker": "^2.1.1",
 		"is-wsl": "^2.2.0"

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ $ npm install open
 ## Usage
 
 ```js
-import open from 'open';
+const open = require('open');
 
 // Opens the image in the default image viewer and waits for the opened app to quit.
 await open('unicorn.png', {wait: true});
@@ -104,11 +104,11 @@ We do not recommend setting this option. The convention for success is exit code
 An object containing auto-detected binary names for common apps. Useful to work around [cross-platform issues](#app).
 
 ```js
-import open, {apps} from 'open';
+const open = require('open');
 
 await open('https://google.com', {
 	app: {
-		name: apps.chrome
+		name: open.apps.chrome
 	}
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -26,22 +26,20 @@ $ npm install open
 ## Usage
 
 ```js
-const open = require('open');
+import open from 'open';
 
-(async () => {
-	// Opens the image in the default image viewer and waits for the opened app to quit.
-	await open('unicorn.png', {wait: true});
-	console.log('The image viewer app quit');
+// Opens the image in the default image viewer and waits for the opened app to quit.
+await open('unicorn.png', {wait: true});
+console.log('The image viewer app quit');
 
-	// Opens the URL in the default browser.
-	await open('https://sindresorhus.com');
+// Opens the URL in the default browser.
+await open('https://sindresorhus.com');
 
-	// Opens the URL in a specified browser.
-	await open('https://sindresorhus.com', {app: 'firefox'});
+// Opens the URL in a specified browser.
+await open('https://sindresorhus.com', {app: 'firefox'});
 
-	// Specify app arguments.
-	await open('https://sindresorhus.com', {app: ['google chrome', '--incognito']});
-})();
+// Specify app arguments.
+await open('https://sindresorhus.com', {app: ['google chrome', '--incognito']});
 ```
 
 ## API
@@ -84,23 +82,13 @@ Do not bring the app to the foreground.
 
 ##### app
 
-Type: `string | string[]`
+Type: `{name: string | string[], arguments?: string[]} | Array<{name: string | string[], arguments: string[]}>`
 
-Specify the app to open the `target` with, or an array with the app and app arguments.
+Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try.
 
-The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows.
+The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
 
 You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
-
-##### url
-
-Type: `boolean`\
-Default: `false`
-
-Uses `URL` to encode the target before executing it.<br>
-We do not recommend using it on targets that are not URLs.
-
-Especially useful when dealing with the [double-quotes on Windows](#double-quotes-on-windows) caveat.
 
 ##### allowNonzeroExitCode
 
@@ -110,6 +98,20 @@ Default: `false`
 Allow the opened app to exit with nonzero exit code when the `wait` option is `true`.
 
 We do not recommend setting this option. The convention for success is exit code zero.
+
+### open.apps
+
+An object containing auto-detected binary names for common apps. Useful to work around [cross-platform issues](#app).
+
+```js
+import open, {apps} from 'open';
+
+await open('https://google.com', {
+	app: {
+		name: apps.chrome
+	}
+});
+```
 
 ## Caveats
 

--- a/readme.md
+++ b/readme.md
@@ -36,10 +36,10 @@ console.log('The image viewer app quit');
 await open('https://sindresorhus.com');
 
 // Opens the URL in a specified browser.
-await open('https://sindresorhus.com', {app: 'firefox'});
+await open('https://sindresorhus.com', {app: {name: 'firefox'}});
 
 // Specify app arguments.
-await open('https://sindresorhus.com', {app: ['google chrome', '--incognito']});
+await open('https://sindresorhus.com', {app: {name: 'google chrome', arguments: '--incognito'}});
 ```
 
 ## API
@@ -101,7 +101,7 @@ We do not recommend setting this option. The convention for success is exit code
 
 ### open.apps
 
-An object containing auto-detected binary names for common apps. Useful to work around [cross-platform issues](#app).
+An object containing auto-detected binary names for common apps. Useful to work around [cross-platform differences](#app).
 
 ```js
 const open = require('open');

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ Do not bring the app to the foreground.
 
 Type: `{name: string | string[], arguments?: string[]} | Array<{name: string | string[], arguments: string[]}>`
 
-Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try.
+Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try. If each app fails, the last error will be thrown.
 
 The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
 

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,11 @@ await open('https://google.com', {
 });
 ```
 
+#### Supported apps
+
+- [`chrome`](https://www.google.com/chrome) - Web browser
+- [`firefox`](https://www.mozilla.org/firefox) - Web browser
+
 ## Caveats
 
 ### Double-quotes on Windows

--- a/test.js
+++ b/test.js
@@ -1,105 +1,68 @@
 import test from 'ava';
-import isWsl from 'is-wsl';
-import open from '.';
-
-let chromeName;
-let firefoxName;
-let chromeWslName;
-let firefoxWslName;
-
-if (process.platform === 'darwin') {
-	chromeName = 'google chrome canary';
-	firefoxName = 'firefox';
-} else if (process.platform === 'win32' || isWsl) {
-	chromeName = 'Chrome';
-	firefoxName = 'C:\\Program Files\\Mozilla Firefox\\firefox.exe';
-	chromeWslName = '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe';
-	firefoxWslName = '/mnt/c/Program Files/Mozilla Firefox/firefox.exe';
-} else if (process.platform === 'linux') {
-	chromeName = 'google-chrome';
-	firefoxName = 'firefox';
-}
+import open from './index.js';
 
 // Tests only checks that opening doesn't return an error
 // it has no way make sure that it actually opened anything.
 
 // These have to be manually verified.
 
-test('open file in default app', async () => {
-	await open('index.js');
+test('open file in default app', async t => {
+	await t.notThrowsAsync(() => open('index.js'));
 });
 
-test('wait for the app to close if wait: true', async () => {
-	await open('https://sindresorhus.com', {wait: true});
+test('wait for the app to close if wait: true', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com', {wait: true}));
 });
 
-test('encode URL if url: true', async () => {
-	await open('https://sindresorhus.com', {url: true});
+test('encode URL if url: true', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com', {url: true}));
 });
 
-test('open URL in default app', async () => {
-	await open('https://sindresorhus.com');
+test('open URL in default app', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com'));
 });
 
-test('open URL in specified app', async () => {
-	await open('https://sindresorhus.com', {app: firefoxName});
+test('open URL in specified app', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com', {app: {name: open.apps.chrome}}));
 });
 
-test('open URL in specified app with arguments', async () => {
-	await open('https://sindresorhus.com', {app: [chromeName, '--incognito']});
+test('open URL in specified app with arguments', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com', {app: {name: open.apps.chrome, arguments: ['--incognito']}}));
 });
 
 test('return the child process when called', async t => {
-	const cp = await open('index.js');
-	t.true('stdout' in cp);
+	const childProcess = await open('index.js');
+	t.true('stdout' in childProcess);
 });
 
-test('open URL with query strings', async () => {
-	await open('https://sindresorhus.com/?abc=123&def=456');
+test('open URL with query strings', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456'));
 });
 
-test('open URL with a fragment', async () => {
-	await open('https://sindresorhus.com#projects');
+test('open URL with a fragment', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com#projects'));
 });
 
-test('open URL with query strings and spaces', async () => {
-	await open('https://sindresorhus.com/?abc=123&def=456&ghi=with spaces');
+test('open URL with query strings and spaces', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456&ghi=with spaces'));
 });
 
-test('open URL with query strings and a fragment', async () => {
-	await open('https://sindresorhus.com/?abc=123&def=456#projects');
+test('open URL with query strings and a fragment', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456#projects'));
 });
 
-test('open URL with query strings and pipes', async () => {
-	await open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h');
+test('open URL with query strings and pipes', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h'));
 });
 
-test('open URL with query strings, spaces, pipes and a fragment', async () => {
-	await open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h spaces#projects');
+test('open URL with query strings, spaces, pipes and a fragment', async t => {
+	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h spaces#projects'));
 });
 
-test('open URL with query strings and URL reserved characters', async () => {
-	await open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F');
+test('open URL with query strings and URL reserved characters', async t => {
+	await t.notThrowsAsync(() => open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F'));
 });
 
-test('open URL with query strings and URL reserved characters with `url` option', async () => {
-	await open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F', {url: true});
+test('open URL with query strings and URL reserved characters with `url` option', async t => {
+	await t.notThrowsAsync(() => open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F', {url: true}));
 });
-
-if (isWsl) {
-	test('open URL in specified Windows app given a WSL path to the app', async () => {
-		await open('https://sindresorhus.com', {app: firefoxWslName});
-	});
-
-	test('open URL in specified Windows app with arguments given a WSL path to the app', async () => {
-		await open('https://sindresorhus.com', {app: [chromeWslName, '--incognito']});
-	});
-
-	test('open URL with query strings and spaces works with `url` option', async () => {
-		await open('https://sindresorhus.com/?abc=123&def=456&ghi=with spaces', {url: true});
-	});
-
-	test('open URL with query strings works with `url` option', async () => {
-		await open('https://sindresorhus.com/?abc=123&def=456', {url: true});
-	});
-}

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-import test from 'ava';
-import open from './index.js';
+const test = require('ava');
+const open = require('.');
 
 // Tests only checks that opening doesn't return an error
 // it has no way make sure that it actually opened anything.

--- a/test.js
+++ b/test.js
@@ -7,27 +7,27 @@ import open from './index.js';
 // These have to be manually verified.
 
 test('open file in default app', async t => {
-	await t.notThrowsAsync(() => open('index.js'));
+	await t.notThrowsAsync(open('index.js'));
 });
 
 test('wait for the app to close if wait: true', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com', {wait: true}));
+	await t.notThrowsAsync(open('https://sindresorhus.com', {wait: true}));
 });
 
 test('encode URL if url: true', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com', {url: true}));
+	await t.notThrowsAsync(open('https://sindresorhus.com', {url: true}));
 });
 
 test('open URL in default app', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com'));
+	await t.notThrowsAsync(open('https://sindresorhus.com'));
 });
 
 test('open URL in specified app', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com', {app: {name: open.apps.chrome}}));
+	await t.notThrowsAsync(open('https://sindresorhus.com', {app: {name: open.apps.chrome}}));
 });
 
 test('open URL in specified app with arguments', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com', {app: {name: open.apps.chrome, arguments: ['--incognito']}}));
+	await t.notThrowsAsync(open('https://sindresorhus.com', {app: {name: open.apps.chrome, arguments: ['--incognito']}}));
 });
 
 test('return the child process when called', async t => {
@@ -36,33 +36,33 @@ test('return the child process when called', async t => {
 });
 
 test('open URL with query strings', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456'));
+	await t.notThrowsAsync(open('https://sindresorhus.com/?abc=123&def=456'));
 });
 
 test('open URL with a fragment', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com#projects'));
+	await t.notThrowsAsync(open('https://sindresorhus.com#projects'));
 });
 
 test('open URL with query strings and spaces', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456&ghi=with spaces'));
+	await t.notThrowsAsync(open('https://sindresorhus.com/?abc=123&def=456&ghi=with spaces'));
 });
 
 test('open URL with query strings and a fragment', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456#projects'));
+	await t.notThrowsAsync(open('https://sindresorhus.com/?abc=123&def=456#projects'));
 });
 
 test('open URL with query strings and pipes', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h'));
+	await t.notThrowsAsync(open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h'));
 });
 
 test('open URL with query strings, spaces, pipes and a fragment', async t => {
-	await t.notThrowsAsync(() => open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h spaces#projects'));
+	await t.notThrowsAsync(open('https://sindresorhus.com/?abc=123&def=456&ghi=w|i|t|h spaces#projects'));
 });
 
 test('open URL with query strings and URL reserved characters', async t => {
-	await t.notThrowsAsync(() => open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F'));
+	await t.notThrowsAsync(open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F'));
 });
 
 test('open URL with query strings and URL reserved characters with `url` option', async t => {
-	await t.notThrowsAsync(() => open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F', {url: true}));
+	await t.notThrowsAsync(open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F', {url: true}));
 });


### PR DESCRIPTION
```js
const open = require('open');

await open('https://google.com', {
	app: {
		name: open.apps.chrome
	}
});
```

Since we're making a breaking change, I went ahead and bumped it up to Node.js 12. However, I'll roll it back if we're not quite ready.

Fixes: #116


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#116: Add app constants for popular apps](https://issuehunt.io/repos/18469325/issues/116)
---
</details>
<!-- /Issuehunt content-->