### PR TITLE
Fix Node.js 12 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ const open = async (target, options) => {
 		}));
 	}
 
-	let {name: app, appArguments = []} = options.app ?? {};
+	let {name: app, appArguments = []} = options.app || {};
 
 	if (Array.isArray(app)) {
 		return pTryEach(app, appName => open(target, {


### PR DESCRIPTION
Nullish coalescing operator was only introduced in Node.JS 14 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_Coalescing_Operator
https://nodejs.org/uk/blog/release/v14.0.0/

Hence, this package is currently not compatible with Node.JS 12