### PR TITLE
Hide PowerShell window on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,8 @@ const open = async (target, options) => {
 			'-NonInteractive',
 			'–ExecutionPolicy',
 			'Bypass',
+			'–WindowStyle',
+			'Hidden',
 			'-EncodedCommand'
 		);
 


### PR DESCRIPTION
Now sometimes there is a blinking powershell window. With option "wait" it can be visible until exit.
I propose open powershell in hidden window