### PR TITLE
Fix the `app.argument` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ const open = async (target, options) => {
 		}));
 	}
 
-	let {name: app, appArguments = []} = options.app || {};
+	let {name: app, arguments: appArguments = []} = options.app || {};
 
 	if (Array.isArray(app)) {
 		return pTryEach(app, appName => open(target, {

--- a/test.js
+++ b/test.js
@@ -27,7 +27,10 @@ test('open URL in specified app', async t => {
 });
 
 test('open URL in specified app with arguments', async t => {
-	await t.notThrowsAsync(open('https://sindresorhus.com', {app: {name: open.apps.chrome, arguments: ['--incognito']}}));
+	await t.notThrowsAsync(async () => {
+		const proc = await open('https://sindresorhus.com', {app: {name: open.apps.chrome, arguments: ['--incognito']}});
+		t.deepEqual(proc.spawnargs, ['open', '-a', open.apps.chrome, 'https://sindresorhus.com', '--args', '--incognito']);
+	});
 });
 
 test('return the child process when called', async t => {


### PR DESCRIPTION
If you specify arguments, it will not be reflected in the spawn command.
This issue is also mentioned in fixes #234.

I add test and fix code.
It will fix this problem.

`options.app` has `arguments` property. However, programmatically, the specified property is being ignored because it is accessing appArguments.