### PR TITLE
WSL: Ignore commented mount point lines in wsl.conf

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const getWslDrivesMountPoint = (() => {
 		}
 
 		const configContent = await fs.readFile(configFilePath, {encoding: 'utf8'});
-		const configMountPoint = /root\s*=\s*(?<mountPoint>.*)/g.exec(configContent);
+		const configMountPoint = /(?<!#.*)root\s*=\s*(?<mountPoint>.*)/g.exec(configContent);
 
 		if (!configMountPoint) {
 			return defaultMountPoint;


### PR DESCRIPTION
The mount point is detected by reading wsl.conf (PR #219), but the regex does not ignore commented lines (see #246). This PR adds a negative lookbehind for lines starting with a hash character.

Fixes #246