### PR TITLE
Add `newInstance` option for macOS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,16 +22,16 @@ declare namespace open {
 		*/
 		readonly background?: boolean;
 
-                /**
-                __macOS only__
+		/**
+		__macOS only__
 
-                Open a new instance of the application(s) even if one is already running.
+		Open a new instance of the application(s) even if one is already running.
 
-                On other platforms, this is always to open a new instance.
+		On other platforms, this is always to open a new instance.
 
-                @default false
-                */
-                readonly newInstance?: boolean;
+		@default false
+		*/
+		readonly newInstance?: boolean;
 
 		/**
 		Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try. If each app fails, the last error will be thrown.

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare namespace open {
 
 		Open a new instance of the app even it's already running.
 
-		For other platforms, this value is always to be true.
+		A new instance is always opened on other platforms.
 
 		@default false
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,9 +25,9 @@ declare namespace open {
 		/**
 		__macOS only__
 
-		Open a new instance of the application(s) even if one is already running.
+		Open a new instance of the app even it's already running.
 
-		On other platforms, this is always to open a new instance.
+		For other platforms, this value is always to be true.
 
 		@default false
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,17 @@ declare namespace open {
 		*/
 		readonly background?: boolean;
 
+                /**
+                __macOS only__
+
+                Open a new instance of the application(s) even if one is already running.
+
+                On other platforms, this is always to open a new instance.
+
+                @default false
+                */
+                readonly newInstance?: boolean;
+
 		/**
 		Specify the `name` of the app to open the `target` with and optionally, app `arguments`. `app` can be an array of apps to try to open and `name` can be an array of app names to try. If each app fails, the last error will be thrown.
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ const open = async (target, options) => {
 	options = {
 		wait: false,
 		background: false,
+		newInstance: false,
 		allowNonzeroExitCode: false,
 		...options
 	};
@@ -113,6 +114,10 @@ const open = async (target, options) => {
 
 		if (options.background) {
 			cliArguments.push('--background');
+		}
+
+		if (options.newInstance) {
+			cliArguments.push('-n');
 		}
 
 		if (app) {

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ const open = async (target, options) => {
 		}
 
 		if (options.newInstance) {
-			cliArguments.push('-n');
+			cliArguments.push('--new');
 		}
 
 		if (app) {

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,15 @@ Default: `false`
 
 Do not bring the app to the foreground.
 
+##### newInstance <sup>(macOS only)</sup>
+
+Type: `boolean`\
+Default: `false`
+
+Open a new instance of the application(s) even if one is already running.
+
+On other platforms, this is always to open a new instance.
+
 ##### app
 
 Type: `{name: string | string[], arguments?: string[]} | Array<{name: string | string[], arguments: string[]}>`

--- a/readme.md
+++ b/readme.md
@@ -85,9 +85,9 @@ Do not bring the app to the foreground.
 Type: `boolean`\
 Default: `false`
 
-Open a new instance of the application(s) even if one is already running.
+Open a new instance of the app even it's already running.
 
-On other platforms, this is always to open a new instance.
+For other platforms, this value is always to be true.
 
 ##### app
 

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ Default: `false`
 
 Open a new instance of the app even it's already running.
 
-For other platforms, this value is always to be true.
+A new instance is always opened on other platforms.
 
 ##### app
 


### PR DESCRIPTION
The open command in macOS will try to reuse existing instance by default.
Adding `open -n` will create a new instance no matter if there is existing instance or not.
For Windows and Linux, the behavior are to create new instances anyway.
The PR proposes to add a macOS only `newInstance` option and by default it's false.

Not sure if the change making sense or not. feel free to comment for better solution.