### PR TITLE
Gracefully handle reused array being passed in

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ const open = async (target, options) => {
 	}
 
 	let {name: app, arguments: appArguments = []} = options.app || {};
+	appArguments = [...appArguments];
 
 	if (Array.isArray(app)) {
 		return pTryEach(app, appName => open(target, {


### PR DESCRIPTION
Description: If win32 target gets added to arguments array in config, not a local copy.

Prerequisites: Windows 10 (any version), JavaScript (any supported version), Google Chrome (any version, to run the test below)
Scenario: execute code below
Result: after first call one private tab gets opened, after second call 2 private tabs get opened, after third call 3 private tabs get opened (et cetera)
Expected result: only one tab opened after every call.

Code:
```javascript
const open = require('open');

function sleep(ms) {
	return new Promise(resolve => setTimeout(resolve, ms));
}

const config = {
	app: {
		name: open.apps.chrome,
		arguments: ['-incognito']
	},
	wait: true
};

(async function() {
	while(true) {
		await open('https://google.com', config);
		await sleep(5000);
	}
}());
````