### PR TITLE
Add `openApp` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,11 +56,11 @@ declare namespace open {
 
 	interface OpenAppOptions extends Omit<Options, 'app'> {
 		/**
-		Optional arguments to open.
+		Arguments passed to the app.
 
-		The app `arguments` are app dependent. Check the app's documentation for what arguments it accepts.
-		 */
-		readonly arguments?: string[];
+		These arguments are app dependent. Check the app's documentation for what arguments it accepts.
+		*/
+		readonly arguments?: readonly string[];
 	}
 
 	type AppName =

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,7 +147,7 @@ declare const open: {
 	await openApp('xcode');
 	```
 	*/
-	openApp: (name: open.App.name, options?: open.OpenAppOptions) => Promise<ChildProcess>;
+	openApp: (name: open.App['name'], options?: open.OpenAppOptions) => Promise<ChildProcess>;
 };
 
 export = open;

--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,32 @@ declare const open: {
 	```
 	*/
 	apps: Record<open.AppName, string | readonly string[]>;
+
+	/**
+	Open an application. Cross-platform.
+
+	Uses the command `open` on macOS, `start` on Windows and `xdg-open` on other platforms.
+
+	There is a caveat for [double-quotes on Windows](https://github.com/sindresorhus/open#double-quotes-on-windows) where all double-quotes are stripped from the `target`.
+
+	@param name - The application you want to open. Can be either builtin supported `open.apps` names or other name supported in platform.
+	@returns The [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
+
+	@example
+	```
+	const {apps, openApp} = require('open');
+
+	// Open Firefox
+	await openApp(apps.firefox);
+
+	// Open Chrome incognito mode
+	await openApp(apps.chrome, ['--incognito']);
+
+	// Open Xcode
+	await openApp('xcode');
+	```
+	*/
+	openApp: (name: string, appArguments?: string[], options?: open.Options) => Promise<ChildProcess>;
 };
 
 export = open;

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,15 @@ declare namespace open {
 		readonly allowNonzeroExitCode?: boolean;
 	}
 
+	interface OpenAppOptions extends Omit<Options, 'app'> {
+		/**
+		Optional arguments to open.
+
+		The app `arguments` are app dependent. Check the app's documentation for what arguments it accepts.
+		 */
+		readonly arguments?: string[];
+	}
+
 	type AppName =
 		| 'chrome'
 		| 'firefox'
@@ -117,13 +126,11 @@ declare const open: {
 	apps: Record<open.AppName, string | readonly string[]>;
 
 	/**
-	Open an application. Cross-platform.
+	Open an app. Cross-platform.
 
 	Uses the command `open` on macOS, `start` on Windows and `xdg-open` on other platforms.
 
-	There is a caveat for [double-quotes on Windows](https://github.com/sindresorhus/open#double-quotes-on-windows) where all double-quotes are stripped from the `target`.
-
-	@param name - The application you want to open. Can be either builtin supported `open.apps` names or other name supported in platform.
+	@param name - The app you want to open. Can be either builtin supported `open.apps` names or other name supported in platform.
 	@returns The [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
 
 	@example
@@ -134,13 +141,13 @@ declare const open: {
 	await openApp(apps.firefox);
 
 	// Open Chrome incognito mode
-	await openApp(apps.chrome, ['--incognito']);
+	await openApp(apps.chrome, {arguments: ['--incognito']});
 
 	// Open Xcode
 	await openApp('xcode');
 	```
 	*/
-	openApp: (name: string, appArguments?: string[], options?: open.Options) => Promise<ChildProcess>;
+	openApp: (name: open.App.name, options?: open.OpenAppOptions) => Promise<ChildProcess>;
 };
 
 export = open;

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ const pTryEach = async (array, mapper) => {
 	throw latestError;
 };
 
-const _openImpl = async options => {
+const baseOpen = async options => {
 	options = {
 		wait: false,
 		background: false,
@@ -79,7 +79,7 @@ const _openImpl = async options => {
 	};
 
 	if (Array.isArray(options.app)) {
-		return pTryEach(options.app, singleApp => _openImpl({
+		return pTryEach(options.app, singleApp => baseOpen({
 			...options,
 			app: singleApp
 		}));
@@ -89,7 +89,7 @@ const _openImpl = async options => {
 	appArguments = [...appArguments];
 
 	if (Array.isArray(app)) {
-		return pTryEach(app, appName => _openImpl({
+		return pTryEach(app, appName => baseOpen({
 			...options,
 			app: {
 				name: appName,
@@ -229,26 +229,27 @@ const open = (target, options) => {
 		throw new TypeError('Expected a `target`');
 	}
 
-	return _openImpl({
+	return baseOpen({
 		...options,
 		target
 	});
 };
 
-const openApp = (name, appArguments, options) => {
+const openApp = (name, options) => {
 	if (typeof name !== 'string') {
 		throw new TypeError('Expected a `name`');
 	}
 
+	const {arguments: appArguments = []} = options || {};
 	if (appArguments !== undefined && appArguments !== null && !Array.isArray(appArguments)) {
 		throw new TypeError('Expected `appArguments` as Array type');
 	}
 
-	return _openImpl({
+	return baseOpen({
 		...options,
 		app: {
 			name,
-			arguments: appArguments || []
+			arguments: appArguments
 		}
 	});
 };

--- a/index.js
+++ b/index.js
@@ -69,11 +69,7 @@ const pTryEach = async (array, mapper) => {
 	throw latestError;
 };
 
-const open = async (target, options) => {
-	if (typeof target !== 'string') {
-		throw new TypeError('Expected a `target`');
-	}
-
+const _openImpl = async options => {
 	options = {
 		wait: false,
 		background: false,
@@ -83,7 +79,7 @@ const open = async (target, options) => {
 	};
 
 	if (Array.isArray(options.app)) {
-		return pTryEach(options.app, singleApp => open(target, {
+		return pTryEach(options.app, singleApp => _openImpl({
 			...options,
 			app: singleApp
 		}));
@@ -93,7 +89,7 @@ const open = async (target, options) => {
 	appArguments = [...appArguments];
 
 	if (Array.isArray(app)) {
-		return pTryEach(app, appName => open(target, {
+		return pTryEach(app, appName => _openImpl({
 			...options,
 			app: {
 				name: appName,
@@ -153,9 +149,11 @@ const open = async (target, options) => {
 			// Double quote with double quotes to ensure the inner quotes are passed through.
 			// Inner quotes are delimited for PowerShell interpretation with backticks.
 			encodedArguments.push(`"\`"${app}\`""`, '-ArgumentList');
-			appArguments.unshift(target);
-		} else {
-			encodedArguments.push(`"${target}"`);
+			if (options.target) {
+				appArguments.unshift(options.target);
+			}
+		} else if (options.target) {
+			encodedArguments.push(`"${options.target}"`);
 		}
 
 		if (appArguments.length > 0) {
@@ -164,7 +162,7 @@ const open = async (target, options) => {
 		}
 
 		// Using Base64-encoded command, accepted by PowerShell, to allow special characters.
-		target = Buffer.from(encodedArguments.join(' '), 'utf16le').toString('base64');
+		options.target = Buffer.from(encodedArguments.join(' '), 'utf16le').toString('base64');
 	} else {
 		if (app) {
 			command = app;
@@ -196,7 +194,9 @@ const open = async (target, options) => {
 		}
 	}
 
-	cliArguments.push(target);
+	if (options.target) {
+		cliArguments.push(options.target);
+	}
 
 	if (platform === 'darwin' && appArguments.length > 0) {
 		cliArguments.push('--args', ...appArguments);
@@ -222,6 +222,35 @@ const open = async (target, options) => {
 	subprocess.unref();
 
 	return subprocess;
+};
+
+const open = (target, options) => {
+	if (typeof target !== 'string') {
+		throw new TypeError('Expected a `target`');
+	}
+
+	return _openImpl({
+		...options,
+		target
+	});
+};
+
+const openApp = (name, appArguments, options) => {
+	if (typeof name !== 'string') {
+		throw new TypeError('Expected a `name`');
+	}
+
+	if (appArguments !== undefined && appArguments !== null && !Array.isArray(appArguments)) {
+		throw new TypeError('Expected `appArguments` as Array type');
+	}
+
+	return _openImpl({
+		...options,
+		app: {
+			name,
+			arguments: appArguments || []
+		}
+	});
 };
 
 function detectArchBinary(binary) {
@@ -280,5 +309,6 @@ defineLazyProperty(apps, 'edge', () => detectPlatformBinary({
 }));
 
 open.apps = apps;
+open.openApp = openApp;
 
 module.exports = open;

--- a/readme.md
+++ b/readme.md
@@ -154,11 +154,11 @@ You may also pass in the app's full path. For example on WSL, this can be `/mnt/
 
 Type: `object`
 
-The options are like the options in [`open`](#options) except to remove `options.app` and add the following options.
+Same options as [`open`](#options) except `app` and with the following additions:
 
 ##### arguments
 
-Type: `Array<string>`
+Type: `string[]`\
 Default: `[]`
 
 The `arguments` are app dependent. Check the app's documentation for what arguments it accepts.

--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,9 @@ Same options as [`open`](#options) except `app` and with the following additions
 Type: `string[]`\
 Default: `[]`
 
-The `arguments` are app dependent. Check the app's documentation for what arguments it accepts.
+Arguments passed to the app.
+
+These arguments are app dependent. Check the app's documentation for what arguments it accepts.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -41,11 +41,11 @@ await open('https://sindresorhus.com', {app: {name: 'firefox'}});
 // Specify app arguments.
 await open('https://sindresorhus.com', {app: {name: 'google chrome', arguments: ['--incognito']}});
 
-// Open app
+// Open an app
 await open.openApp('xcode');
 
-// Open app with arguments
-await open.openApp(open.apps.chrome, ['--incognito']);
+// Open an app with arguments
+await open.openApp(open.apps.chrome, {arguments: ['--incognito']});
 ```
 
 ## API
@@ -136,23 +136,32 @@ await open('https://google.com', {
 - [`firefox`](https://www.mozilla.org/firefox) - Web browser
 - [`edge`](https://www.microsoft.com/edge) - Web browser
 
-### open.openApp(name, appArguments?, options?)
+### open.openApp(name, options?)
+
+Open an app.
 
 Returns a promise for the [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
 
 #### name
 
+Type: `string`
+
 The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
 
 You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
 
-#### appArguments
-
-The `appArguments` are app dependent. Check the app's documentation for what arguments it accepts.
-
 #### options
 
-The options are like the options in `open` except `options.app` is not supported here.
+Type: `object`
+
+The options are like the options in [`open`](#options) except to remove `options.app` and add the following options.
+
+##### arguments
+
+Type: `Array<string>`
+Default: `[]`
+
+The `arguments` are app dependent. Check the app's documentation for what arguments it accepts.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,12 @@ await open('https://sindresorhus.com', {app: {name: 'firefox'}});
 
 // Specify app arguments.
 await open('https://sindresorhus.com', {app: {name: 'google chrome', arguments: ['--incognito']}});
+
+// Open app
+await open.openApp('xcode');
+
+// Open app with arguments
+await open.openApp(open.apps.chrome, ['--incognito']);
 ```
 
 ## API
@@ -129,6 +135,24 @@ await open('https://google.com', {
 - [`chrome`](https://www.google.com/chrome) - Web browser
 - [`firefox`](https://www.mozilla.org/firefox) - Web browser
 - [`edge`](https://www.microsoft.com/edge) - Web browser
+
+### open.openApp(name, appArguments?, options?)
+
+Returns a promise for the [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
+
+#### name
+
+The app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows. If possible, use [`open.apps`](#openapps) which auto-detects the correct binary to use.
+
+You may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.
+
+#### appArguments
+
+The `appArguments` are app dependent. Check the app's documentation for what arguments it accepts.
+
+#### options
+
+The options are like the options in `open` except `options.app` is not supported here.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const test = require('ava');
 const open = require('.');
+const {openApp} = open;
 
 // Tests only checks that opening doesn't return an error
 // it has no way make sure that it actually opened anything.
@@ -68,4 +69,12 @@ test('open URL with query strings and URL reserved characters', async t => {
 
 test('open URL with query strings and URL reserved characters with `url` option', async t => {
 	await t.notThrowsAsync(open('https://httpbin.org/get?amp=%26&colon=%3A&comma=%2C&commat=%40&dollar=%24&equals=%3D&plus=%2B&quest=%3F&semi=%3B&sol=%2F', {url: true}));
+});
+
+test('open Firefox without arguments', async t => {
+	await t.notThrowsAsync(openApp(open.apps.firefox));
+});
+
+test('open Chrome in incognito mode', async t => {
+	await t.notThrowsAsync(openApp(open.apps.chrome, ['--incognito'], {newInstance: true}));
 });

--- a/test.js
+++ b/test.js
@@ -76,5 +76,5 @@ test('open Firefox without arguments', async t => {
 });
 
 test('open Chrome in incognito mode', async t => {
-	await t.notThrowsAsync(openApp(open.apps.chrome, ['--incognito'], {newInstance: true}));
+	await t.notThrowsAsync(openApp(open.apps.chrome, {arguments: ['--incognito'], newInstance: true}));
 });


### PR DESCRIPTION
`open` is good to facilitate cross platform opening. sometimes i just want to open an application without specifying url or file target. the concept is something like `open(null, { app: { name: open.apps.chrome }});`. this pr just introduces an `openApp` api. please help to review if the concept makes sense.