### PR TITLE
Don't use empty catch blocks please

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ const getWslDrivesMountPoint = (() => {
 		try {
 			await fs.access(configFilePath, fsConstants.F_OK);
 			isConfigFileExists = true;
-		} catch {}
+		} catch (error) {
+			console.error("Access error in npm module 'open'.");
+		}
 
 		if (!isConfigFileExists) {
 			return defaultMountPoint;


### PR DESCRIPTION
I suppose a change to not use an empty catch block and at least print an error message.