### PR TITLE
On WSL, invoke `app` like on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ const baseOpen = async options => {
 		if (app) {
 			cliArguments.push('-a', app);
 		}
-	} else if (platform === 'win32' || (isWsl && !isDocker())) {
+	} else if (platform === 'win32' || (isWsl && !isDocker() && !app)) {
 		const mountPoint = await getWslDrivesMountPoint();
 
 		command = isWsl ?


### PR DESCRIPTION
This pr handles the `app` property on WSL the same as on Linux. The reason being that while one can invoke Windows PowerShell (or even a Windows browser) from the WSL shell, afaik one can't use Windows PowerShell or the Windows [START](https://ss64.com/nt/start.html) command to run WSL binaries. They can be run directly from the WSL shell though like on Linux.

This pr also provides a way to fixes #293, namely by setting the `app.name` property to a WSL browser binary like `google-chrome`.