### PR TITLE
Fix issue with `allowNonzeroExitCode`

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,7 +209,7 @@ const baseOpen = async options => {
 			subprocess.once('error', reject);
 
 			subprocess.once('close', exitCode => {
-				if (options.allowNonzeroExitCode && exitCode > 0) {
+				if (!options.allowNonzeroExitCode && exitCode > 0) {
 					reject(new Error(`Exited with code ${exitCode}`));
 					return;
 				}


### PR DESCRIPTION
The behavior for rejecting on a non-zero exit code was flipped, resulting in applications which exited abnormally resolving the promise successfully.