### PR TITLE
Fix systemroot inconsistent casing (Fixes #292)

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ const baseOpen = async options => {
 
 		command = isWsl ?
 			`${mountPoint}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe` :
-			`${process.env.SYSTEMROOT}\\System32\\WindowsPowerShell\\v1.0\\powershell`;
+			`${process.env.SYSTEMROOT || process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell`;
 
 		cliArguments.push(
 			'-NoProfile',


### PR DESCRIPTION
Long time no PR, sindresorhus 😄 

This PR simply adds a fallback for casing differences in `SYSTEMROOT` across windows versions, currently when using this on W11 (at least the 3 versions I tested) `SYSTEMROOT` was undefined, however `SystemRoot` _is_ defined.

So, try and use both

Fixes #292 

