### PR TITLE
Prevents package from crashing when import.meta.url is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ import defaultBrowser from 'default-browser';
 import isInsideContainer from 'is-inside-container';
 
 // Path to included `xdg-open`.
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.url ? path.dirname(fileURLToPath(import.meta.url)) : '';
 const localXdgOpenPath = path.join(__dirname, 'xdg-open');
 
 const {platform, arch} = process;


### PR DESCRIPTION
This PR prevents `open` from crashing when the package is bundled for non-ESM format. 
It does so by adding a simple _truthy_ guard for `import.meta.url` before passing it to `fileURLToPath()` function.

In non-ESM context, `import.meta.url` is `undefined`. 
https://github.com/sindresorhus/open/blob/36c61af1e696ef4365fd12dcc733586877106f19/index.js#L13-L15

And since `fileURLToPath()` does not accept `undefined` value as argument, it will throw the following error: 

```shell
node:internal/url:1210
    throw new ERR_INVALID_ARG_TYPE('path', ['string', 'URL'], path);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of URL. Received undefined
...
```
