### PR TITLE
Fix passed an illegal parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ const baseOpen = async options => {
 		}
 
 		if (appArguments.length > 0) {
-			appArguments = appArguments.map(arg => `"\`"${arg}\`""`);
+			appArguments = appArguments.map(arg => `"${arg}"`);
 			encodedArguments.push('-ArgumentList', appArguments.join(','));
 		}
 


### PR DESCRIPTION
Hi, if I pass parameters to openApp, the program will not recognize it, and it will work normally after removing the extra quotes.