### PR TITLE
Escape quotes in arguments for PowerShell

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ const baseOpen = async options => {
 		}
 
 		if (appArguments.length > 0) {
-			appArguments = appArguments.map(arg => `"\`"${arg}\`""`);
+			appArguments = appArguments.map(arg => `"\`"${String.prototype.replaceAll.call(arg, '"', '`"')}\`""`);
 			encodedArguments.push('-ArgumentList', appArguments.join(','));
 		}
 

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ const baseOpen = async options => {
 		}
 
 		if (appArguments.length > 0) {
-			appArguments = appArguments.map(arg => `"\`"${String.prototype.replaceAll.call(arg, '"', '`"')}\`""`);
+			appArguments = appArguments.map(arg => `"\`"${String(arg).replaceAll('"', '`"')}\`""`);
 			encodedArguments.push('-ArgumentList', appArguments.join(','));
 		}
 


### PR DESCRIPTION
A fix for #318. This is just a simple patch and can of course be changed if necessary.

The `String.prototype.replaceAll.call(arg, ...)` instead of just `arg.replaceAll(...)` is because `appArguments` might contain things other than strings.

This doesn't add escaping to the app name itself.

I'm not sure if you want to set up a unit test for this scenario, and I'm not sure if this change marks a breaking API change (if some people already put <code>\`</code> in their strings even though that wouldn't work on other platforms).