### PR TITLE
fix(windows): add windir and C:/Windows as fallback on non-WSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ const baseOpen = async options => {
 
 		command = isWsl
 			? `${mountPoint}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe`
-			: `${process.env.SYSTEMROOT}\\System32\\WindowsPowerShell\\v1.0\\powershell`;
+			: `${process.env.SYSTEMROOT || process.env.windir || 'C:\\Windows'}\\System32\\WindowsPowerShell\\v1.0\\powershell`;
 
 		cliArguments.push(
 			'-NoProfile',


### PR DESCRIPTION
related: https://github.com/vitejs/vite/issues/14292 https://github.com/vitejs/vite/discussions/14293

Not seeing `SYSTEMROOT` being provided on the environment on my system.

```bash  
System:
    OS: Windows 11 10.0.22621
    CPU: (32) x64 AMD Ryzen 9 7950X 16-Core Processor
    Memory: 35.64 GB / 63.14 GB
  Binaries:
    Node: 20.10.0 - C:\Program Files\nodejs\node.EXE
    Yarn: 1.22.21 - C:\Program Files\nodejs\yarn.CMD
    npm: 10.2.3 - C:\Program Files\nodejs\npm.CMD
    pnpm: 8.12.0 - ~\AppData\Local\pnpm\pnpm.EXE
  Browsers:
    Edge: Chromium (120.0.2210.77)
    Internet Explorer: 11.0.22621.1
```

`windir` seems to be providing the same path and just in case added the default `C:\\Windows` as a fallback.

