### PR TITLE
fix: update `openApp(app)` to not error when `app` is an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,8 +281,8 @@ const open = (target, options) => {
 };
 
 export const openApp = (name, options) => {
-	if (typeof name !== 'string') {
-		throw new TypeError('Expected a `name`');
+	if (typeof name !== 'string' && !Array.isArray(name)) {
+		throw new TypeError('Expected a valid `name`');
 	}
 
 	const {arguments: appArguments = []} = options ?? {};


### PR DESCRIPTION
`openApp(apps.chrome)` is one of the examples in the [documentation](https://www.npmjs.com/package/open):
```
// Open an app with arguments.
await openApp(apps.chrome, {arguments: ['--incognito']});
```

However this fails on WSL because `openApp` asserts that the `app` arguement is a string, but `apps.chrome` is an array of strings.

This PR fixes the issue by allowing arrays as well in the type check.

Repro steps:
- Open WSL
- Clone this repo https://github.com/raymondji/open-openApp-repro
- Run `node index.js`

Expected result:
- Opens chrome

Got result:
- Error: "TypeError: Expected a name"

Testing done:
- Do the same repro steps, but run `node index.js --withFix` instead
- Verified this opens chrome as expected