### PR TITLE
Add support for Plasma (KDE) 6

### DIFF
--- a/xdg-open
+++ b/xdg-open
@@ -617,6 +617,9 @@ open_kde()
         5)
           kde-open${KDE_SESSION_VERSION} "$1"
         ;;
+        6)
+          kde-open "$1"
+        ;;
       esac
     else
         kfmclient exec "$1"


### PR DESCRIPTION
Several notes worth mentioning:

- This should be good enough until Plasma 7 is released years from now (Plasma 6 was released roughly ten years after Plasma 5).
- However, it would be nicer if, in such a case, the script would fail (instead of doing nothing as it does now). I didn't want to go there but perhaps adding a "default" branch calling `exit_failure_operation_failed` would be the way to go?
- I'm expecting `kde-open` to be present under Plasma 6. This is the case on Arch Linux; I can't speak for other distributions. However, looking at how it is packaged on Arch, I don't see any weird customization, so I expect that if you build `kde-cli-tools` elsewhere, you will have `kde-open`, too.

Fixes #336.