### PR TITLE
add `xdg-open` to module exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,11 @@
 	},
 	"type": "module",
 	"exports": {
-		"types": "./index.d.ts",
-		"default": "./index.js"
+		".": {
+			"types": "./index.d.ts",
+			"default": "./index.js"
+		},
+		"./xdg-open": "./xdg-open"
 	},
 	"sideEffects": false,
 	"engines": {


### PR DESCRIPTION
We bundle this package with `esbuild`. It will be usefull to add `xdg-open` to module exports so we can resolve it's path and copy to `build` folder.

Usage example:
```js
import path from 'node:path';
import { createRequire } from 'node:module';
import fs from 'node:fs/promises';

const require = createRequire(import.meta.url);

await fs.copyFile(
  require.resolve('open/xdg-open'),
  path.join('build', 'xdg-open')
);
```