### PR TITLE
fix: support Single Executable Applications

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ import defaultBrowser from 'default-browser';
 import isInsideContainer from 'is-inside-container';
 
 // Path to included `xdg-open`.
-const __dirname = path.dirname(fileURLToPath(import.meta.url || process.execPath));
+const self = import.meta.url;
+const __dirname = path.dirname(self ? fileURLToPath(self) : process.execPath);
 const localXdgOpenPath = path.join(__dirname, 'xdg-open');
 
 const {platform, arch} = process;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import defaultBrowser from 'default-browser';
 import isInsideContainer from 'is-inside-container';
 
 // Path to included `xdg-open`.
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = path.dirname(fileURLToPath(import.meta.url || process.execPath));
 const localXdgOpenPath = path.join(__dirname, 'xdg-open');
 
 const {platform, arch} = process;


### PR DESCRIPTION
I'm using this module with Node's new [Single Executable Application functionality](https://nodejs.org/api/single-executable-applications.html). Currently this requires you to bundle your application into a single JavaScript file, which I'm doing with esbuild. However, when importing the module, it chokes over
```js
const __dirname = path.dirname(fileURLToPath(import.meta.url));
```
because after bundling with esbuild, `import.meta.url` is undefined.

This PR fixes that by falling back to `process.execPath` in case `import.meta.url` is `undefined`. This also means that if someone wants to use the bundled xdg binary, they can distribute it alongside the sea binary and it should work.