### PR TITLE
fix: add microsoft edgemac id

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,7 @@ const baseOpen = async options => {
 			'firefox.desktop': 'firefox',
 			'com.microsoft.msedge': 'edge',
 			'com.microsoft.edge': 'edge',
+			'com.microsoft.edgemac': 'edge',
 			'microsoft-edge.desktop': 'edge',
 		};
 


### PR DESCRIPTION
Fixes #355.

I've added the `com.microsoft.edgemac` id to the registered list of ids.