### PR TITLE
feat: add function to detect Windows default browser from WSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,11 +80,7 @@ Get the default browser name in Windows from WSL.
 */
 async function getWindowsDefaultBrowserFromWsl() {
 	const powershellPath = await getPowershellPathFromWsl();
-
-	const rawCommand = `$prog = Get-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice' | Select-Object -ExpandProperty ProgId
-	Write-Output $prog
-	`.trim();
-
+	const rawCommand = '(Get-ItemProperty -Path "HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice").ProgId';
 	const encodedCommand = Buffer.from(rawCommand, 'utf16le').toString('base64');
 
 	const {stdout, stderr} = await execFile(

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ async function getWindowsDefaultBrowserFromWsl() {
 	const rawCommand = '(Get-ItemProperty -Path "HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice").ProgId';
 	const encodedCommand = Buffer.from(rawCommand, 'utf16le').toString('base64');
 
-	const {stdout, stderr} = await execFile(
+	const {stdout} = await execFile(
 		powershellPath,
 		[
 			'-NoProfile',
@@ -95,10 +95,6 @@ async function getWindowsDefaultBrowserFromWsl() {
 		],
 		{encoding: 'utf8'},
 	);
-
-	if (stderr && !stderr.includes('CLIXML')) {
-		throw new Error(stderr);
-	}
 
 	const progId = stdout.trim();
 

--- a/index.js
+++ b/index.js
@@ -68,37 +68,43 @@ async function getWindowsDefaultBrowserFromWsl() {
 	const mountPoint = await getWslDrivesMountPoint();
 	const powershellPath = `${mountPoint}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe`;
 
-	const rawCommand =
-		`$prog = Get-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice' | Select-Object -ExpandProperty ProgId
+	const rawCommand
+		= `$prog = Get-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice' | Select-Object -ExpandProperty ProgId
 	Write-Output $prog
 	`.trim();
-	const encodedCommand = Buffer.from(rawCommand, "utf16le").toString("base64");
+	const encodedCommand = Buffer.from(rawCommand, 'utf16le').toString('base64');
 
 	return new Promise((resolve, reject) => {
 		execFile(
 			powershellPath,
 			[
-				"-NoProfile",
-				"-NonInteractive",
-				"-ExecutionPolicy",
-				"Bypass",
-				"-EncodedCommand",
+				'-NoProfile',
+				'-NonInteractive',
+				'-ExecutionPolicy',
+				'Bypass',
+				'-EncodedCommand',
 				encodedCommand,
 			],
-			{ encoding: "utf8" },
-			(err, stdout, stderr) => {
-				if (err) return reject(err);
+			{encoding: 'utf8'},
+			(error, stdout, stderr) => {
+				if (error) {
+					return reject(error);
+				}
+
+				if (stderr) {
+					return reject(new Error(stderr));
+				}
 
 				const progId = stdout.trim();
 
 				// Map ProgId to browser IDs
 				const browserMap = {
-					ChromeHTML: "com.google.chrome",
-					MSEdgeHTM: "com.microsoft.edge",
-					FirefoxURL: "org.mozilla.firefox",
+					ChromeHTML: 'com.google.chrome',
+					MSEdgeHTM: 'com.microsoft.edge',
+					FirefoxURL: 'org.mozilla.firefox',
 				};
 
-				resolve(progId ? { id: browserMap[progId] } : {});
+				resolve(progId ? {id: browserMap[progId]} : {});
 			},
 		);
 	});

--- a/index.js
+++ b/index.js
@@ -64,25 +64,27 @@ const getWslDrivesMountPoint = (() => {
 })();
 
 /**
- * Get the PowerShell executable path in WSL environment.
- * @returns {Promise<string>} The full path to the PowerShell executable in WSL
- */
+Get the PowerShell executable path in WSL environment.
+
+@returns {Promise<string>} The absolute path to the PowerShell executable in WSL.
+*/
 const getPowershellPathFromWsl = async () => {
 	const mountPoint = await getWslDrivesMountPoint();
 	return `${mountPoint}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe`;
 };
 
 /**
- * Get the default browser name in Windows from WSL.
- * @returns {Promise<string>} Browser name
- */
+Get the default browser name in Windows from WSL.
+
+@returns {Promise<string>} Browser name.
+*/
 async function getWindowsDefaultBrowserFromWsl() {
 	const powershellPath = await getPowershellPathFromWsl();
 
-	const rawCommand
-		= `$prog = Get-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice' | Select-Object -ExpandProperty ProgId
+	const rawCommand = `$prog = Get-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice' | Select-Object -ExpandProperty ProgId
 	Write-Output $prog
 	`.trim();
+
 	const encodedCommand = Buffer.from(rawCommand, 'utf16le').toString('base64');
 
 	const {stdout, stderr} = await execFile(


### PR DESCRIPTION
related issue: #357

To provide additional explanation on this issue, I found that in order for the user to change `x-scheme-handler/http`, the actual .desktop file must exist.
To forcefully change it, you would need to modify `/usr/share/applications/defaults.list`, but I thought this wasn't the common behavior.
Therefore, I wrote a function to get the default browser in Windows using a PowerShell command, and linked it with the `browser.id` value, so that if `isWsl` is true, the function would be executed.

## Changes

- Added getWindowsDefaultBrowser() to retrieve the default Windows browser from WSL
- Maps ProgId (e.g. ChromeHTML) to existing IDs