### PR TITLE
feat: add brave-browser

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,7 @@ export type OpenAppOptions = {
 
 export type AppName =
 	| 'chrome'
+	| 'brave'
 	| 'firefox'
 	| 'edge'
 	| 'browser'

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ async function getWindowsDefaultBrowserFromWsl() {
 	// Map ProgId to browser IDs
 	const browserMap = {
 		ChromeHTML: 'com.google.chrome',
+		BraveHTML: 'com.brave.Browser',
 		MSEdgeHTM: 'com.microsoft.edge',
 		FirefoxURL: 'org.mozilla.firefox',
 	};
@@ -101,6 +102,7 @@ const baseOpen = async options => {
 		const ids = {
 			'com.google.chrome': 'chrome',
 			'google-chrome.desktop': 'chrome',
+			'com.brave.Browser': 'brave',
 			'org.mozilla.firefox': 'firefox',
 			'firefox.desktop': 'firefox',
 			'com.microsoft.msedge': 'edge',
@@ -112,6 +114,7 @@ const baseOpen = async options => {
 		// Incognito flags for each browser in `apps`.
 		const flags = {
 			chrome: '--incognito',
+			brave: '--incognito',
 			firefox: '--private-window',
 			edge: '--inPrivate',
 		};
@@ -325,6 +328,17 @@ defineLazyProperty(apps, 'chrome', () => detectPlatformBinary({
 	wsl: {
 		ia32: '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe',
 		x64: ['/mnt/c/Program Files/Google/Chrome/Application/chrome.exe', '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'],
+	},
+}));
+
+defineLazyProperty(apps, 'brave', () => detectPlatformBinary({
+	darwin: 'brave browser',
+	win32: 'brave',
+	linux: ['brave-browser', 'brave'],
+}, {
+	wsl: {
+		ia32: '/mnt/c/Program Files (x86)/BraveSoftware/Brave-Browser/Application/brave.exe',
+		x64: ['/mnt/c/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe', '/mnt/c/Program Files (x86)/BraveSoftware/Brave-Browser/Application/brave.exe'],
 	},
 }));
 

--- a/readme.md
+++ b/readme.md
@@ -171,10 +171,11 @@ await open('https://google.com', {
 - [`chrome`](https://www.google.com/chrome) - Web browser
 - [`firefox`](https://www.mozilla.org/firefox) - Web browser
 - [`edge`](https://www.microsoft.com/edge) - Web browser
+- [`brave`](https://brave.com/) - Web browser
 - `browser` - Default web browser
 - `browserPrivate` - Default web browser in incognito mode
 
-`browser` and `browserPrivate` only supports `chrome`, `firefox`, and `edge`.
+`browser` and `browserPrivate` only supports `chrome`, `firefox`, `edge`, and `brave`.
 
 ## Related
 

--- a/test-it.js
+++ b/test-it.js
@@ -1,0 +1,4 @@
+import open, {apps, openApp} from 'open';
+
+await open('https://brave.com', {app: {name: apps.brave}});
+await openApp(apps.brave, {arguments: ['https://brave.com', '--incognito'], newInstance: true});

--- a/test.js
+++ b/test.js
@@ -78,6 +78,10 @@ test('open Chrome in incognito mode', async t => {
 	await t.notThrowsAsync(openApp(apps.chrome, {arguments: ['--incognito'], newInstance: true}));
 });
 
+test('open Brave in incognito mode', async t => {
+	await t.notThrowsAsync(openApp(apps.brave, {arguments: ['--incognito'], newInstance: true}));
+});
+
 test('open URL with default browser argument', async t => {
 	await t.notThrowsAsync(open('https://sindresorhus.com', {app: {name: apps.browser}}));
 });


### PR DESCRIPTION
### Features
- Add Brave (privacy-oriented clone of Chromium)
- Add integration test (not actually run by `npm test`, but useful for development)