### PR TITLE
Detach non-wait PowerShell launches

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,7 @@ const baseOpen = async options => {
 			// PowerShell will keep the parent process alive unless stdio is ignored.
 			childProcessOptions.stdio = 'ignore';
 			childProcessOptions.detached = true;
+			childProcessOptions.windowsHide = true;
 		}
 	} else {
 		if (app) {

--- a/index.js
+++ b/index.js
@@ -207,6 +207,7 @@ const baseOpen = async options => {
 		if (!options.wait) {
 			// PowerShell will keep the parent process alive unless stdio is ignored.
 			childProcessOptions.stdio = 'ignore';
+			childProcessOptions.detached = true;
 		}
 	} else {
 		if (app) {

--- a/test.js
+++ b/test.js
@@ -176,6 +176,7 @@ test.serial('detaches PowerShell launches when not waiting on Windows', async t 
 		windowsVerbatimArguments: true,
 		stdio: 'ignore',
 		detached: true,
+		windowsHide: true,
 	});
 	t.true(unrefCalled);
 });

--- a/test.js
+++ b/test.js
@@ -139,6 +139,47 @@ test('subprocess is spawned before promise resolves', async t => {
 	t.true(childProcess.pid !== undefined && childProcess.pid !== null);
 });
 
+test.serial('detaches PowerShell launches when not waiting on Windows', async t => {
+	const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+	const originalSpawn = childProcess.spawn;
+
+	t.teardown(() => {
+		Object.defineProperty(process, 'platform', originalPlatform);
+		childProcess.spawn = originalSpawn;
+	});
+
+	Object.defineProperty(process, 'platform', {value: 'win32'});
+
+	let childProcessOptions;
+	let unrefCalled = false;
+
+	childProcess.spawn = (...arguments_) => {
+		childProcessOptions = arguments_[2];
+
+		// eslint-disable-next-line unicorn/prefer-event-target
+		const fakeChild = new EventEmitter();
+		fakeChild.unref = () => {
+			unrefCalled = true;
+		};
+
+		setImmediate(() => {
+			fakeChild.emit('spawn');
+		});
+
+		return fakeChild;
+	};
+
+	const {default: windowsOpen} = await import(`./index.js?windows-detach=${Date.now()}`);
+	await windowsOpen('C:/coverage/index.html');
+
+	t.like(childProcessOptions, {
+		windowsVerbatimArguments: true,
+		stdio: 'ignore',
+		detached: true,
+	});
+	t.true(unrefCalled);
+});
+
 test.serial('app launches resolve before close without fallback', async t => {
 	const originalSpawn = childProcess.spawn;
 	t.teardown(() => {


### PR DESCRIPTION
Summary:
- detach non-wait PowerShell launches after stdio is ignored so Windows targets can keep opening after the parent process exits
- add an AVA regression test that loads the module with `process.platform` mocked to `win32` and verifies the spawn options

Tests:
- `npm_config_cache=/tmp/open-npm-cache npx ava test.js --match="detaches PowerShell launches when not waiting on Windows"`
- `npm_config_cache=/tmp/open-npm-cache npx ava test.js --match="app launches resolve before close without fallback" --match="detaches PowerShell launches when not waiting on Windows"`
- `npm_config_cache=/tmp/open-npm-cache npm test`
- `git diff --check`

Fixes #367