### PR TITLE
fix: use own-property check for default browser id lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,8 +112,11 @@ const baseOpen = async options => {
 			browser = await defaultBrowser();
 		}
 
-		if (browser.id in ids) {
+		if (Object.hasOwn(ids, browser.id)) {
 			const browserName = ids[browser.id.toLowerCase()];
+			if (browserName === undefined) {
+				throw new Error(`${browser.name} is not supported as a default browser`);
+			}
 
 			if (app === 'browserPrivate') {
 				// Safari doesn't support private mode via command line

--- a/test/proto-keys.js
+++ b/test/proto-keys.js
@@ -1,0 +1,14 @@
+import test from 'ava';
+
+// Regression: browser ids that collide with Object.prototype keys must be
+// rejected as unsupported instead of resolving to a function via the
+// prototype chain (`browser.id in ids` was true for e.g. "constructor").
+test('prototype keys do not pass an Object.hasOwn check', t => {
+	const ids = {};
+
+	for (const key of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__']) {
+		t.false(Object.hasOwn(ids, key), `own-check must fail for ${key}`);
+	}
+
+	t.true(Object.hasOwn({'com.google.chrome': 'chrome'}, 'com.google.chrome'));
+});


### PR DESCRIPTION
`browser.id in ids` also matches `Object.prototype` keys. A default browser whose id collides with a prototype key passed the check, resolved to an inherited function through `ids[id]`, and produced `apps[function] === undefined` — launching a bogus `"undefined"` app instead of failing with "`X` is not supported as a default browser".

On Windows the id comes from the registry (`default-browser` reads the user-writable `HKCU` ProgId), so an id like `constructor` or `toString` is reachable in practice.

## Before

```js
const browser = {id: 'constructor', name: 'MyProgId'};
// 'constructor' in ids → true (prototype)
// ids['constructor'] → Object constructor function
// apps[fn] → undefined → spawn "undefined"
```

## Fix

Use `Object.hasOwn(ids, browser.id)` and throw the existing unsupported-browser error for any id that does not map to a known browser.

## Test

`test/proto-keys.js` locks the own-property semantics the fix relies on.
